### PR TITLE
Test using responses

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -5,3 +5,4 @@ nose==1.3.7
 tox==3.14.6
 black==19.10b0; python_version >= "3.6"
 pre-commit==2.2.0
+responses==0.10.12

--- a/tests/zoomus/components/meeting/test_create.py
+++ b/tests/zoomus/components/meeting/test_create.py
@@ -1,12 +1,8 @@
 import datetime
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
 from zoomus import components, util
+import responses
 
 
 def suite():
@@ -20,20 +16,21 @@ def suite():
 class CreateV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.meeting.MeetingComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
+    @responses.activate
     def test_can_create(self):
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            self.component.create(host_id="ID", topic="TOPIC", type="TYPE")
-
-            mock_post_request.assert_called_with(
-                "/meeting/create",
-                params={"host_id": "ID", "topic": "TOPIC", "type": "TYPE"},
-            )
+        responses.add(
+            responses.POST,
+            "http://foo.com/meeting/create?host_id=ID&topic=TOPIC&type=TYPE&api_key=KEY&api_secret=SECRET",
+        )
+        self.component.create(host_id="ID", topic="TOPIC", type="TYPE")
 
     def test_requires_host_id(self):
         with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
@@ -47,52 +44,49 @@ class CreateV1TestCase(unittest.TestCase):
         with self.assertRaisesRegexp(ValueError, "'type' must be set"):
             self.component.create(host_id="ID", topic="TOPIC")
 
-    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
-    def test_does_convert_startime_to_str_if_datetime(self, mock_post_request):
-        start_time = datetime.datetime.utcnow()
+    @responses.activate
+    def test_does_convert_startime_to_str_if_datetime(self):
+        responses.add(
+            responses.POST,
+            "http://foo.com/meeting/create?host_id=ID&topic=TOPIC&type=TYPE&api_key=KEY&api_secret=SECRET&start_time=2020-01-01T01%3A01%3A00Z",
+        )
+        start_time = datetime.datetime(2020, 1, 1, 1, 1)
         self.component.create(
             host_id="ID", topic="TOPIC", type="TYPE", start_time=start_time
-        )
-
-        mock_post_request.assert_called_with(
-            "/meeting/create",
-            params={
-                "host_id": "ID",
-                "topic": "TOPIC",
-                "type": "TYPE",
-                "start_time": util.date_to_str(start_time),
-            },
         )
 
 
 class CreateV2TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.meeting.MeetingComponentV2(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
-    def test_can_create(self, mock_post_request):
+    @responses.activate
+    def test_can_create(self):
+        responses.add(
+            responses.POST,
+            "http://foo.com/users/ID/meetings?user_id=ID&topic=TOPIC&type=TYPE",
+        )
         self.component.create(user_id="ID", topic="TOPIC", type="TYPE")
-
-        mock_post_request.assert_called_with(
-            "/users/ID/meetings",
-            data={"user_id": "ID", "topic": "TOPIC", "type": "TYPE"},
-        )
 
     def test_requires_user_id(self):
         with self.assertRaisesRegexp(ValueError, "'user_id' must be set"):
             self.component.create()
 
-    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
-    def test_does_convert_startime_to_str_if_datetime(self, mock_post_request):
-        start_time = datetime.datetime.utcnow()
-        self.component.create(user_id="ID", start_time=start_time)
-
-        mock_post_request.assert_called_with(
-            "/users/ID/meetings",
-            data={"user_id": "ID", "start_time": util.date_to_str(start_time)},
+    @responses.activate
+    def test_does_convert_startime_to_str_if_datetime(self):
+        responses.add(
+            responses.POST,
+            "http://foo.com/users/ID/meetings?user_id=ID&start_time=2020-01-01T01%3A01%3A00Z",
         )
+        start_time = datetime.datetime(2020, 1, 1, 1, 1)
+        self.component.create(user_id="ID", start_time=start_time)
 
 
 if __name__ == "__main__":

--- a/tests/zoomus/components/meeting/test_create.py
+++ b/tests/zoomus/components/meeting/test_create.py
@@ -70,10 +70,12 @@ class CreateV2TestCase(unittest.TestCase):
     @responses.activate
     def test_can_create(self):
         responses.add(
-            responses.POST,
-            "http://foo.com/users/ID/meetings?user_id=ID&topic=TOPIC&type=TYPE",
+            responses.POST, "http://foo.com/users/ID/meetings",
         )
-        self.component.create(user_id="ID", topic="TOPIC", type="TYPE")
+        response = self.component.create(user_id="ID", topic="TOPIC", type="TYPE")
+        self.assertEqual(
+            response.request.body, '{"user_id": "ID", "topic": "TOPIC", "type": "TYPE"}'
+        )
 
     def test_requires_user_id(self):
         with self.assertRaisesRegexp(ValueError, "'user_id' must be set"):
@@ -82,11 +84,14 @@ class CreateV2TestCase(unittest.TestCase):
     @responses.activate
     def test_does_convert_startime_to_str_if_datetime(self):
         responses.add(
-            responses.POST,
-            "http://foo.com/users/ID/meetings?user_id=ID&start_time=2020-01-01T01%3A01%3A00Z",
+            responses.POST, "http://foo.com/users/ID/meetings",
         )
         start_time = datetime.datetime(2020, 1, 1, 1, 1)
-        self.component.create(user_id="ID", start_time=start_time)
+        response = self.component.create(user_id="ID", start_time=start_time)
+        self.assertEqual(
+            response.request.body,
+            '{"user_id": "ID", "start_time": "2020-01-01T01:01:00Z"}',
+        )
 
 
 if __name__ == "__main__":

--- a/tests/zoomus/components/meeting/test_delete.py
+++ b/tests/zoomus/components/meeting/test_delete.py
@@ -1,11 +1,7 @@
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
-from zoomus import components
+from zoomus import components, util
+import responses
 
 
 def suite():
@@ -19,41 +15,46 @@ def suite():
 class DeleteV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.meeting.MeetingComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
+    @responses.activate
     def test_can_delete(self):
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            self.component.delete(id="ID", host_id="ID")
-
-            mock_post_request.assert_called_with(
-                "/meeting/delete", params={"id": "ID", "host_id": "ID"}
-            )
+        responses.add(
+            responses.POST,
+            "http://foo.com/meeting/delete?id=ID&host_id=ID&api_key=KEY&api_secret=SECRET",
+        )
+        self.component.delete(id="ID", host_id="ID")
 
     def test_requires_id(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
             self.component.delete()
-            self.assertEqual(context.exception.message, "'id' must be set")
 
     def test_requires_host_id(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
             self.component.delete(id="ID")
-            self.assertEqual(context.exception.message, "'host_id' must be set")
 
 
 class DeleteV2TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.meeting.MeetingComponentV2(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "delete_request", return_value=True)
-    def test_can_delete(self, mock_delete_request):
+    @responses.activate
+    def test_can_delete(self):
+        responses.add(responses.DELETE, "http://foo.com/meetings/ID?id=ID")
         self.component.delete(id="ID")
-        mock_delete_request.assert_called_with("/meetings/ID", params={"id": "ID"})
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):

--- a/tests/zoomus/components/meeting/test_end.py
+++ b/tests/zoomus/components/meeting/test_end.py
@@ -1,11 +1,7 @@
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
-from zoomus import components
+from zoomus import components, util
+import responses
 
 
 def suite():
@@ -18,29 +14,29 @@ def suite():
 class EndV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.meeting.MeetingComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
+    @responses.activate
     def test_can_end(self):
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            self.component.end(id="ID", host_id="ID")
-
-            mock_post_request.assert_called_with(
-                "/meeting/end", params={"id": "ID", "host_id": "ID"}
-            )
+        responses.add(
+            responses.POST,
+            "http://foo.com/meeting/end?id=ID&host_id=ID&api_key=KEY&api_secret=SECRET",
+        )
+        self.component.end(id="ID", host_id="ID")
 
     def test_requires_id(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
             self.component.end()
-            self.assertEqual(context.exception.message, "'id' must be set")
 
     def test_requires_host_id(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
             self.component.end(id="ID")
-            self.assertEqual(context.exception.message, "'host_id' must be set")
 
 
 if __name__ == "__main__":

--- a/tests/zoomus/components/meeting/test_get.py
+++ b/tests/zoomus/components/meeting/test_get.py
@@ -51,6 +51,7 @@ class GetV2TestCase(unittest.TestCase):
             },
         )
 
+    @responses.activate
     def test_can_get(self):
         responses.add(responses.GET, "http://foo.com/meetings/ID")
         self.component.get(id="ID")

--- a/tests/zoomus/components/meeting/test_get.py
+++ b/tests/zoomus/components/meeting/test_get.py
@@ -1,11 +1,7 @@
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
-from zoomus import components
+from zoomus import components, util
+import responses
 
 
 def suite():
@@ -19,41 +15,45 @@ def suite():
 class GetV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.meeting.MeetingComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
+    @responses.activate
     def test_can_get(self):
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            self.component.get(id="ID", host_id="ID")
-
-            mock_post_request.assert_called_with(
-                "/meeting/get", params={"id": "ID", "host_id": "ID"}
-            )
+        responses.add(
+            responses.POST,
+            "http://foo.com/meeting/get?id=ID&host_id=ID&api_key=KEY&api_secret=SECRET",
+        )
+        self.component.get(id="ID", host_id="ID")
 
     def test_requires_id(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
             self.component.get()
-            self.assertEqual(context.exception.message, "'id' must be set")
 
     def test_requires_host_id(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
             self.component.get(id="ID")
-            self.assertEqual(context.exception.message, "'host_id' must be set")
 
 
 class GetV2TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.meeting.MeetingComponentV2(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
-    def test_can_get(self, mock_get_request):
+    def test_can_get(self):
+        responses.add(responses.GET, "http://foo.com/meetings/ID")
         self.component.get(id="ID")
-        mock_get_request.assert_called_with("/meetings/ID", params={"id": "ID"})
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):

--- a/tests/zoomus/components/meeting/test_list.py
+++ b/tests/zoomus/components/meeting/test_list.py
@@ -1,12 +1,8 @@
 import datetime
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
 from zoomus import components, util
+import responses
 
 
 def suite():
@@ -20,60 +16,54 @@ def suite():
 class ListV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.meeting.MeetingComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
+    @responses.activate
     def test_can_list(self):
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            self.component.list(host_id="ID")
-
-            mock_post_request.assert_called_with(
-                "/meeting/list", params={"host_id": "ID"}
-            )
+        responses.add(
+            responses.POST,
+            "http://foo.com/meeting/list?host_id=ID&api_key=KEY&api_secret=SECRET",
+        )
+        self.component.list(host_id="ID")
 
     def test_requires_host_id(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
             self.component.list()
-            self.assertEqual(context.exception.message, "'host_id' must be set")
 
+    @responses.activate
     def test_does_convert_startime_to_str_if_datetime(self):
-
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            start_time = datetime.datetime.utcnow()
-            self.component.list(
-                host_id="ID", topic="TOPIC", type="TYPE", start_time=start_time
-            )
-
-            mock_post_request.assert_called_with(
-                "/meeting/list",
-                params={
-                    "host_id": "ID",
-                    "topic": "TOPIC",
-                    "type": "TYPE",
-                    "start_time": util.date_to_str(start_time),
-                },
-            )
+        responses.add(
+            responses.POST,
+            "http://foo.com/meeting/list?host_id=ID&topic=TOPIC&type=TYPE&start_time=2020-01-01T01%3A01%3A00Z"
+            "&api_key=KEY&api_secret=SECRET",
+        )
+        start_time = datetime.datetime(2020, 1, 1, 1, 1)
+        self.component.list(
+            host_id="ID", topic="TOPIC", type="TYPE", start_time=start_time
+        )
 
 
 class ListV2TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.meeting.MeetingComponentV2(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
-    def test_can_list(self, mock_get_request):
+    @responses.activate
+    def test_can_list(self):
+        responses.add(responses.GET, "http://foo.com/users/ID/meetings?user_id=ID")
         self.component.list(user_id="ID")
-
-        mock_get_request.assert_called_with(
-            "/users/ID/meetings", params={"user_id": "ID"}
-        )
 
     def test_requires_user_id(self):
         with self.assertRaisesRegexp(ValueError, "'user_id' must be set"):

--- a/tests/zoomus/components/meeting/test_update.py
+++ b/tests/zoomus/components/meeting/test_update.py
@@ -64,8 +64,9 @@ class UpdateV2TestCase(unittest.TestCase):
 
     @responses.activate
     def test_can_update(self):
-        responses.add(responses.PATCH, "http://foo.com/meetings/42?id=42&foo=bar")
-        self.component.update(id="42", foo="bar")
+        responses.add(responses.PATCH, "http://foo.com/meetings/42")
+        response = self.component.update(id="42", foo="bar")
+        self.assertEqual(response.request.body, '{"id": "42", "foo": "bar"}')
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):
@@ -74,10 +75,12 @@ class UpdateV2TestCase(unittest.TestCase):
     @responses.activate
     def test_start_time_gets_transformed(self):
         responses.add(
-            responses.PATCH,
-            "http://foo.com/meetings/42?id=42&start_time=2020-01-01T01%3A01%3A00Z",
+            responses.PATCH, "http://foo.com/meetings/42",
         )
-        self.component.update(id="42", start_time=datetime(2020, 1, 1, 1, 1))
+        response = self.component.update(id="42", start_time=datetime(2020, 1, 1, 1, 1))
+        self.assertEqual(
+            response.request.body, '{"id": "42", "start_time": "2020-01-01T01:01:00Z"}'
+        )
 
 
 if __name__ == "__main__":

--- a/tests/zoomus/components/meeting/test_update.py
+++ b/tests/zoomus/components/meeting/test_update.py
@@ -1,12 +1,8 @@
 from datetime import datetime
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
-from zoomus import components
+from zoomus import components, util
+import responses
 
 
 def suite():
@@ -20,64 +16,68 @@ def suite():
 class UpdateV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.meeting.MeetingComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
+    @responses.activate
     def test_can_update(self):
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            self.component.update(id="ID", host_id="ID")
-
-            mock_post_request.assert_called_with(
-                "/meeting/update", params={"id": "ID", "host_id": "ID"}
-            )
+        responses.add(
+            responses.POST,
+            "http://foo.com/meeting/update?id=ID&host_id=ID&api_key=KEY&api_secret=SECRET",
+        )
+        self.component.update(id="ID", host_id="ID")
 
     def test_requires_id(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
             self.component.update()
-            self.assertEqual(context.exception.message, "'id' must be set")
 
     def test_requires_host_id(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
             self.component.update(id="ID")
-            self.assertEqual(context.exception.message, "'host_id' must be set")
 
-    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
-    def test_start_time_gets_transformed(self, mock_post_request):
-        self.component.update(id="ID", host_id="ID", start_time=datetime(1969, 1, 1))
-        mock_post_request.assert_called_with(
-            "/meeting/update",
-            params={"id": "ID", "host_id": "ID", "start_time": "1969-01-01T00:00:00Z"},
+    @responses.activate
+    def test_start_time_gets_transformed(self):
+        responses.add(
+            responses.POST,
+            "http://foo.com/meeting/update?id=ID&host_id=ID&start_time=2020-01-01T01%3A01%3A00Z"
+            "&api_key=KEY&api_secret=SECRET",
         )
+        start_time = datetime(2020, 1, 1, 1, 1)
+        self.component.update(id="ID", host_id="ID", start_time=start_time)
 
 
 class UpdateV2TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.meeting.MeetingComponentV2(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "patch_request", return_value=True)
-    def test_can_update(self, mock_post_request):
+    @responses.activate
+    def test_can_update(self):
+        responses.add(responses.PATCH, "http://foo.com/meetings/42?id=42&foo=bar")
         self.component.update(id="42", foo="bar")
 
-        mock_post_request.assert_called_with(
-            "/meetings/42", data={"id": "42", "foo": "bar"}
-        )
-
     def test_requires_id(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
             self.component.update()
-            self.assertEqual(context.exception.message, "'id' must be set")
 
-    @patch.object(components.base.BaseComponent, "patch_request", return_value=True)
-    def test_start_time_gets_transformed(self, mock_patch_request):
-        self.component.update(id="42", start_time=datetime(1969, 1, 1))
-        mock_patch_request.assert_called_with(
-            "/meetings/42", data={"id": "42", "start_time": "1969-01-01T00:00:00Z"}
+    @responses.activate
+    def test_start_time_gets_transformed(self):
+        responses.add(
+            responses.PATCH,
+            "http://foo.com/meetings/42?id=42&start_time=2020-01-01T01%3A01%3A00Z",
         )
+        self.component.update(id="42", start_time=datetime(2020, 1, 1, 1, 1))
 
 
 if __name__ == "__main__":

--- a/tests/zoomus/components/past_meeting/test_get.py
+++ b/tests/zoomus/components/past_meeting/test_get.py
@@ -6,6 +6,7 @@ except ImportError:
     from mock import patch
 
 from zoomus import components
+import responses
 
 
 def suite():
@@ -21,12 +22,13 @@ class GetV2TestCase(unittest.TestCase):
             base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
-    def test_can_get(self, mock_get_request):
-        self.component.get(meeting_id="ID")
-        mock_get_request.assert_called_with(
-            "/past_meetings/ID", params={"meeting_id": "ID"}
+    @responses.activate
+    def test_can_get(self):
+        responses.add(
+            responses.GET,
+            "http://foo.com/past_meetings/ID?meeting_id=ID"
         )
+        self.component.get(meeting_id="ID")
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'meeting_id' must be set"):

--- a/tests/zoomus/components/past_meeting/test_get.py
+++ b/tests/zoomus/components/past_meeting/test_get.py
@@ -1,10 +1,5 @@
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
 from zoomus import components
 import responses
 

--- a/tests/zoomus/components/past_meeting/test_get.py
+++ b/tests/zoomus/components/past_meeting/test_get.py
@@ -24,10 +24,7 @@ class GetV2TestCase(unittest.TestCase):
 
     @responses.activate
     def test_can_get(self):
-        responses.add(
-            responses.GET,
-            "http://foo.com/past_meetings/ID?meeting_id=ID"
-        )
+        responses.add(responses.GET, "http://foo.com/past_meetings/ID?meeting_id=ID")
         self.component.get(meeting_id="ID")
 
     def test_requires_id(self):

--- a/tests/zoomus/components/past_meeting/test_list.py
+++ b/tests/zoomus/components/past_meeting/test_list.py
@@ -7,6 +7,7 @@ except ImportError:
     from mock import patch
 
 from zoomus import components, util
+import responses
 
 
 def suite():
@@ -22,13 +23,13 @@ class ListV2TestCase(unittest.TestCase):
             base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
-    def test_can_list(self, mock_get_request):
-        self.component.list(meeting_id="ID")
-
-        mock_get_request.assert_called_with(
-            "/past_meetings/ID/instances", params={"meeting_id": "ID"}
+    @responses.activate
+    def test_can_list(self):
+        responses.add(
+            responses.GET,
+            "http://foo.com/past_meetings/ID/instances?meeting_id=ID"
         )
+        self.component.list(meeting_id="ID")
 
     def test_requires_user_id(self):
         with self.assertRaisesRegexp(ValueError, "'meeting_id' must be set"):

--- a/tests/zoomus/components/past_meeting/test_list.py
+++ b/tests/zoomus/components/past_meeting/test_list.py
@@ -1,11 +1,6 @@
 import datetime
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
 from zoomus import components, util
 import responses
 

--- a/tests/zoomus/components/past_meeting/test_list.py
+++ b/tests/zoomus/components/past_meeting/test_list.py
@@ -26,8 +26,7 @@ class ListV2TestCase(unittest.TestCase):
     @responses.activate
     def test_can_list(self):
         responses.add(
-            responses.GET,
-            "http://foo.com/past_meetings/ID/instances?meeting_id=ID"
+            responses.GET, "http://foo.com/past_meetings/ID/instances?meeting_id=ID"
         )
         self.component.list(meeting_id="ID")
 

--- a/tests/zoomus/components/recording/test_delete.py
+++ b/tests/zoomus/components/recording/test_delete.py
@@ -1,11 +1,7 @@
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
-from zoomus import components
+from zoomus import components, util
+import responses
 
 
 def suite():
@@ -18,38 +14,44 @@ def suite():
 class DeleteV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.recording.RecordingComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
+    @responses.activate
     def test_can_delete(self):
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            self.component.delete(meeting_id="ID")
-
-            mock_post_request.assert_called_with(
-                "/recording/delete", params={"meeting_id": "ID"}
-            )
+        responses.add(
+            responses.POST,
+            "http://foo.com/recording/delete?meeting_id=ID&api_key=KEY&api_secret=SECRET",
+        )
+        self.component.delete(meeting_id="ID")
 
     def test_requires_id(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegexp(ValueError, "'meeting_id' must be set"):
             self.component.delete()
-            self.assertEqual(context.exception.message, "'meeting_id' must be set")
 
 
 class DeleteV2TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.recording.RecordingComponentV2(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "delete_request", return_value=True)
-    def test_can_delete(self, mock_delete_request):
-        self.component.delete(meeting_id="ID")
-        mock_delete_request.assert_called_with(
-            "/meetings/ID/recordings", params={"meeting_id": "ID"}
+    @responses.activate
+    def test_can_delete(self):
+        responses.add(
+            responses.DELETE, "http://foo.com/meetings/42/recordings?meeting_id=42"
         )
+        self.component.delete(meeting_id="42")
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'meeting_id' must be set"):

--- a/tests/zoomus/components/recording/test_get.py
+++ b/tests/zoomus/components/recording/test_get.py
@@ -1,11 +1,7 @@
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
-from zoomus import components
+from zoomus import components, util
+import responses
 
 
 def suite():
@@ -18,38 +14,44 @@ def suite():
 class GetV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.recording.RecordingComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
+    @responses.activate
     def test_can_get(self):
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            self.component.get(meeting_id="ID")
-
-            mock_post_request.assert_called_with(
-                "/recording/get", params={"meeting_id": "ID"}
-            )
+        responses.add(
+            responses.POST,
+            "http://foo.com/recording/get?meeting_id=ID&api_key=KEY&api_secret=SECRET",
+        )
+        self.component.get(meeting_id="ID")
 
     def test_requires_id(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegexp(ValueError, "'meeting_id' must be set"):
             self.component.get()
-            self.assertEqual(context.exception.message, "'meeting_id' must be set")
 
 
 class GetV2TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.recording.RecordingComponentV2(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
-    def test_can_get(self, mock_get_request):
-        self.component.get(meeting_id="ID")
-        mock_get_request.assert_called_with(
-            "/meetings/ID/recordings", params={"meeting_id": "ID"}
+    @responses.activate
+    def test_can_get(self):
+        responses.add(
+            responses.GET, "http://foo.com/meetings/42/recordings?meeting_id=42"
         )
+        self.component.get(meeting_id="42")
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'meeting_id' must be set"):

--- a/tests/zoomus/components/recording/test_list.py
+++ b/tests/zoomus/components/recording/test_list.py
@@ -1,12 +1,8 @@
 import datetime
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
 from zoomus import components, util
+import responses
 
 
 def suite():
@@ -19,81 +15,71 @@ def suite():
 class ListV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.recording.RecordingComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
+    @responses.activate
     def test_can_list(self):
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            self.component.list(host_id="ID")
-
-            mock_post_request.assert_called_with(
-                "/recording/list", params={"host_id": "ID"}
-            )
+        responses.add(
+            responses.POST,
+            "http://foo.com/recording/list?host_id=ID&api_key=KEY&api_secret=SECRET",
+        )
+        self.component.list(host_id="ID")
 
     def test_requires_host_id(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
             self.component.list()
-            self.assertEqual(context.exception.message, "'host_id' must be set")
 
+    @responses.activate
     def test_does_convert_startime_to_str_if_datetime(self):
-
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            start_time = datetime.datetime.utcnow() - datetime.timedelta(days=10)
-            end_time = datetime.datetime.utcnow()
-            self.component.list(
-                host_id="ID", start=start_time, end=end_time, meeting_number="111"
-            )
-
-            mock_post_request.assert_called_with(
-                "/recording/list",
-                params={
-                    "host_id": "ID",
-                    "from": util.date_to_str(start_time),
-                    "to": util.date_to_str(end_time),
-                    "meeting_number": "111",
-                },
-            )
+        start_time = datetime.datetime(1969, 1, 1, 1, 1)
+        end_time = datetime.datetime(2020, 1, 1, 1, 1)
+        responses.add(
+            responses.POST,
+            "http://foo.com/recording/list?host_id=42&meeting_number=111&api_key=KEY&api_secret=SECRET"
+            "&from=1969-01-01T01%3A01%3A00Z&to=2020-01-01T01%3A01%3A00Z",
+        )
+        self.component.list(
+            host_id="42", start=start_time, end=end_time, meeting_number="111"
+        )
 
 
 class ListV2TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.recording.RecordingComponentV2(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
-    def test_can_list(self, mock_get_request):
-        self.component.list(user_id="ID")
-        mock_get_request.assert_called_with(
-            "/users/ID/recordings", params={"user_id": "ID"}
-        )
+    @responses.activate
+    def test_can_list(self):
+        responses.add(responses.GET, "http://foo.com/users/42/recordings?user_id=42")
+        self.component.list(user_id="42")
 
     def test_requires_user_id(self):
         with self.assertRaisesRegexp(ValueError, "'user_id' must be set"):
             self.component.list()
 
-    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
-    def test_does_convert_startime_to_str_if_datetime(self, mock_get_request):
-        start_time = datetime.datetime.utcnow() - datetime.timedelta(days=10)
-        end_time = datetime.datetime.utcnow()
-        self.component.list(
-            user_id="ID", start=start_time, end=end_time, meeting_number="111"
+    @responses.activate
+    def test_does_convert_startime_to_str_if_datetime(self):
+        responses.add(
+            responses.GET,
+            "http://foo.com/users/42/recordings?user_id=42&meeting_number=111"
+            "&from=1969-01-01T01%3A01%3A00Z&to=2020-01-01T01%3A01%3A00Z",
         )
-
-        mock_get_request.assert_called_with(
-            "/users/ID/recordings",
-            params={
-                "user_id": "ID",
-                "from": util.date_to_str(start_time),
-                "to": util.date_to_str(end_time),
-                "meeting_number": "111",
-            },
+        start_time = datetime.datetime(1969, 1, 1, 1, 1)
+        end_time = datetime.datetime(2020, 1, 1, 1, 1)
+        self.component.list(
+            user_id="42", start=start_time, end=end_time, meeting_number="111"
         )
 
 

--- a/tests/zoomus/components/report/test_get_account_report.py
+++ b/tests/zoomus/components/report/test_get_account_report.py
@@ -1,12 +1,8 @@
 import datetime
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
 from zoomus import components, util
+import responses
 
 
 def suite():
@@ -20,75 +16,24 @@ def suite():
 class GetAccountReportV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.report.ReportComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
-        )
-
-    def test_can_get_account_report(self):
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            start_time = datetime.datetime.utcnow()
-            end_time = datetime.datetime.utcnow()
-            self.component.get_account_report(start_time=start_time, end_time=end_time)
-
-            mock_post_request.assert_called_with(
-                "/report/getaccountreport",
-                params={
-                    "from": util.date_to_str(start_time),
-                    "to": util.date_to_str(end_time),
-                },
-            )
-
-    def test_requires_start_time(self):
-        with self.assertRaises(ValueError) as context:
-            self.component.get_account_report()
-            self.assertEqual(context.exception.message, "'start_time' must be set")
-
-    def test_requires_end_time(self):
-        with self.assertRaises(ValueError) as context:
-            self.component.get_account_report(start_time=datetime.datetime.utcnow())
-            self.assertEqual(context.exception.message, "'end_time' must be set")
-
-    def test_does_convert_start_time_to_str_if_datetime(self):
-
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            start_time = datetime.datetime.utcnow()
-            end_time = datetime.datetime.utcnow()
-
-            self.component.get_account_report(start_time=start_time, end_time=end_time)
-
-            mock_post_request.assert_called_with(
-                "/report/getaccountreport",
-                params={
-                    "from": util.date_to_str(start_time),
-                    "to": util.date_to_str(end_time),
-                },
-            )
-
-
-class GetAccountReportV2TestCase(unittest.TestCase):
-    def setUp(self):
-        self.component = components.report.ReportComponentV2(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
-        )
-
-    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
-    def test_can_get_account_report(self, mock_get_request):
-        start_time = datetime.datetime.utcnow()
-        end_time = datetime.datetime.utcnow()
-        self.component.get_account_report(start_time=start_time, end_time=end_time)
-
-        mock_get_request.assert_called_with(
-            "/report/users",
-            params={
-                "from": util.date_to_str(start_time),
-                "to": util.date_to_str(end_time),
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
             },
         )
+
+    @responses.activate
+    def test_can_get_account_report(self):
+        start_time = datetime.datetime(1969, 1, 1, 1, 1)
+        end_time = datetime.datetime(2020, 1, 1, 1, 1)
+        responses.add(
+            responses.POST,
+            "http://foo.com/report/getaccountreport?from=1969-01-01T01%3A01%3A00Z&to=2020-01-01T01%3A01%3A00Z"
+            "&api_key=KEY&api_secret=SECRET",
+        )
+        self.component.get_account_report(start_time=start_time, end_time=end_time)
 
     def test_requires_start_time(self):
         with self.assertRaisesRegexp(ValueError, "'start_time' must be set"):
@@ -98,20 +43,35 @@ class GetAccountReportV2TestCase(unittest.TestCase):
         with self.assertRaisesRegexp(ValueError, "'end_time' must be set"):
             self.component.get_account_report(start_time=datetime.datetime.utcnow())
 
-    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
-    def test_does_convert_start_time_to_str_if_datetime(self, mock_get_request):
-        start_time = datetime.datetime.utcnow()
-        end_time = datetime.datetime.utcnow()
 
-        self.component.get_account_report(start_time=start_time, end_time=end_time)
-
-        mock_get_request.assert_called_with(
-            "/report/users",
-            params={
-                "from": util.date_to_str(start_time),
-                "to": util.date_to_str(end_time),
+class GetAccountReportV2TestCase(unittest.TestCase):
+    def setUp(self):
+        self.component = components.report.ReportComponentV2(
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
             },
         )
+
+    @responses.activate
+    def test_can_get_account_report(self):
+        start_time = datetime.datetime(1969, 1, 1, 1, 1)
+        end_time = datetime.datetime(2020, 1, 1, 1, 1)
+        responses.add(
+            responses.GET,
+            "http://foo.com/report/users?from=1969-01-01T01%3A01%3A00Z&to=2020-01-01T01%3A01%3A00Z",
+        )
+        self.component.get_account_report(start_time=start_time, end_time=end_time)
+
+    def test_requires_start_time(self):
+        with self.assertRaisesRegexp(ValueError, "'start_time' must be set"):
+            self.component.get_account_report()
+
+    def test_requires_end_time(self):
+        with self.assertRaisesRegexp(ValueError, "'end_time' must be set"):
+            self.component.get_account_report(start_time=datetime.datetime.utcnow())
 
 
 if __name__ == "__main__":

--- a/tests/zoomus/components/report/test_get_daily_report.py
+++ b/tests/zoomus/components/report/test_get_daily_report.py
@@ -1,11 +1,8 @@
 import datetime
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-from zoomus import components
+from zoomus import components, util
+import responses
 
 
 def suite():
@@ -19,22 +16,23 @@ def suite():
 class GetDailyReportV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.report.ReportComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
-    def test_can_get_Daily_report(self):
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
+    @responses.activate
+    def test_can_get_daily_report(self):
+        responses.add(
+            responses.POST,
+            "http://foo.com/report/getdailyreport?month=01&year=2020"
+            "&api_key=KEY&api_secret=SECRET",
+        )
 
-            month = datetime.datetime.now().strftime("%m")
-            year = datetime.datetime.now().strftime("%Y")
-
-            self.component.get_daily_report(month=month, year=year)
-
-            mock_post_request.assert_called_with(
-                "/report/getdailyreport", params={"month": month, "year": year},
-            )
+        self.component.get_daily_report(month="01", year="2020")
 
     def test_requires_month(self):
         with self.assertRaises(ValueError) as context:
@@ -48,21 +46,6 @@ class GetDailyReportV1TestCase(unittest.TestCase):
             )
             self.assertEqual(context.exception.message, "'year' must be set")
 
-    def test_does_convert_start_time_to_str_if_datetime(self):
-
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            month = datetime.datetime.now().strftime("%m")
-            year = datetime.datetime.now().strftime("%Y")
-
-            self.component.get_daily_report(month=month, year=year)
-
-            mock_post_request.assert_called_with(
-                "/report/getdailyreport", params={"month": month, "year": year},
-            )
-
 
 class GetDailyReportV2TestCase(unittest.TestCase):
     def setUp(self):
@@ -70,17 +53,10 @@ class GetDailyReportV2TestCase(unittest.TestCase):
             base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
-    def test_can_get_Daily_report(self, mock_get_request):
-
-        month = datetime.datetime.now().strftime("%m")
-        year = datetime.datetime.now().strftime("%Y")
-
-        self.component.get_daily_report(month=month, year=year)
-
-        mock_get_request.assert_called_with(
-            "/report/daily", params={"month": month, "year": year},
-        )
+    @responses.activate
+    def test_can_get_daily_report(self):
+        responses.add(responses.GET, "http://foo.com/report/daily?month=01&year=2020")
+        self.component.get_daily_report(month="01", year="2020")
 
     def test_requires_month(self):
         with self.assertRaisesRegex(ValueError, "'month' must be set"):
@@ -91,18 +67,6 @@ class GetDailyReportV2TestCase(unittest.TestCase):
             self.component.get_daily_report(
                 month=datetime.datetime.now().strftime("%Y")
             )
-
-    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
-    def test_does_convert_start_time_to_str_if_datetime(self, mock_get_request):
-
-        month = datetime.datetime.now().strftime("%m")
-        year = datetime.datetime.now().strftime("%Y")
-
-        self.component.get_daily_report(month=month, year=year)
-
-        mock_get_request.assert_called_with(
-            "/report/daily", params={"month": month, "year": year},
-        )
 
 
 if __name__ == "__main__":

--- a/tests/zoomus/components/report/test_get_user_report.py
+++ b/tests/zoomus/components/report/test_get_user_report.py
@@ -1,12 +1,8 @@
 import datetime
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
 from zoomus import components, util
+import responses
 
 
 def suite():
@@ -20,77 +16,56 @@ def suite():
 class GetUserReportV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.report.ReportComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
+    @responses.activate
     def test_can_get_user_report(self):
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            start_time = datetime.datetime.utcnow()
-            end_time = datetime.datetime.utcnow()
-            self.component.get_user_report(start_time=start_time, end_time=end_time)
-
-            mock_post_request.assert_called_with(
-                "/report/getuserreport",
-                params={
-                    "from": util.date_to_str(start_time),
-                    "to": util.date_to_str(end_time),
-                },
-            )
+        start_time = datetime.datetime(1969, 1, 1, 1, 1)
+        end_time = datetime.datetime(2020, 1, 1, 1, 1)
+        responses.add(
+            responses.POST,
+            "http://foo.com/report/getuserreport?from=1969-01-01T01%3A01%3A00Z&to=2020-01-01T01%3A01%3A00Z"
+            "&api_key=KEY&api_secret=SECRET",
+        )
+        self.component.get_user_report(start_time=start_time, end_time=end_time)
 
     def test_requires_start_time(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegexp(ValueError, "'start_time' must be set"):
             self.component.get_user_report()
-            self.assertEqual(context.exception.message, "'start_time' must be set")
 
     def test_requires_end_time(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegexp(ValueError, "'end_time' must be set"):
             self.component.get_user_report(start_time=datetime.datetime.utcnow())
-            self.assertEqual(context.exception.message, "'end_time' must be set")
-
-    def test_does_convert_start_time_to_str_if_datetime(self):
-
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            start_time = datetime.datetime.utcnow()
-            end_time = datetime.datetime.utcnow()
-
-            self.component.get_user_report(start_time=start_time, end_time=end_time)
-
-            mock_post_request.assert_called_with(
-                "/report/getuserreport",
-                params={
-                    "from": util.date_to_str(start_time),
-                    "to": util.date_to_str(end_time),
-                },
-            )
 
 
 class GetUserReportV2TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.report.ReportComponentV2(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
-        )
-
-    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
-    def test_can_get_user_report(self, mock_get_request):
-        start_time = datetime.datetime.utcnow()
-        end_time = datetime.datetime.utcnow()
-        self.component.get_user_report(
-            user_id="ID", start_time=start_time, end_time=end_time
-        )
-
-        mock_get_request.assert_called_with(
-            "/report/users/ID/meetings",
-            params={
-                "user_id": "ID",
-                "from": util.date_to_str(start_time),
-                "to": util.date_to_str(end_time),
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
             },
+        )
+
+    @responses.activate
+    def test_can_get_user_report(self):
+        start_time = datetime.datetime(1969, 1, 1, 1, 1)
+        end_time = datetime.datetime(2020, 1, 1, 1, 1)
+        responses.add(
+            responses.GET,
+            "http://foo.com/report/users/42/meetings?user_id=42"
+            "&from=1969-01-01T01%3A01%3A00Z&to=2020-01-01T01%3A01%3A00Z",
+        )
+        self.component.get_user_report(
+            user_id="42", start_time=start_time, end_time=end_time
         )
 
     def test_requires_user_id(self):
@@ -106,24 +81,6 @@ class GetUserReportV2TestCase(unittest.TestCase):
             self.component.get_user_report(
                 user_id="ID", start_time=datetime.datetime.utcnow()
             )
-
-    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
-    def test_does_convert_start_time_to_str_if_datetime(self, mock_get_request):
-        start_time = datetime.datetime.utcnow()
-        end_time = datetime.datetime.utcnow()
-
-        self.component.get_user_report(
-            user_id="ID", start_time=start_time, end_time=end_time
-        )
-
-        mock_get_request.assert_called_with(
-            "/report/users/ID/meetings",
-            params={
-                "user_id": "ID",
-                "from": util.date_to_str(start_time),
-                "to": util.date_to_str(end_time),
-            },
-        )
 
 
 if __name__ == "__main__":

--- a/tests/zoomus/components/test_base.py
+++ b/tests/zoomus/components/test_base.py
@@ -1,11 +1,7 @@
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
-from zoomus import API_VERSION_1, API_VERSION_2, components
+from zoomus import components, util
+import responses
 
 
 def suite():
@@ -15,59 +11,55 @@ def suite():
     return suite
 
 
-@mock.patch("zoomus.components.base.util.ApiClient.post_request")
 class BaseComponentTestCase(unittest.TestCase):
-    def test_post_request_includes_config_details_in_data_when_no_data(
-        self, mock_post_request
-    ):
-        component = components.base.BaseComponent(
-            base_uri="http://www.foo.com",
-            config={"api_key": "KEY", "api_secret": "SECRET", "version": API_VERSION_1},
-        )
-        component.post_request("foo")
-        mock_post_request.assert_called_with(
-            "foo",
-            params={"api_key": "KEY", "api_secret": "SECRET"},
-            data=None,
-            headers=None,
-            cookies=None,
-        )
-
-    def test_post_request_includes_config_details_in_data_when_there_is_data(
-        self, mock_post_request
-    ):
-        component = components.base.BaseComponent(
-            base_uri="http://www.foo.com",
-            config={"api_key": "KEY", "api_secret": "SECRET", "version": API_VERSION_1},
-        )
-        component.post_request("foo", params={"foo": "bar"})
-
-        mock_post_request.assert_called_with(
-            "foo",
-            params={"foo": "bar", "api_key": "KEY", "api_secret": "SECRET"},
-            data=None,
-            headers=None,
-            cookies=None,
-        )
-
-    def test_v2_post_request_passes_jwt_token(self, mock_post_request):
+    @responses.activate
+    def test_post_request_includes_config_details_in_data_when_no_data(self):
         component = components.base.BaseComponent(
             base_uri="http://www.foo.com",
             config={
                 "api_key": "KEY",
                 "api_secret": "SECRET",
-                "version": API_VERSION_2,
+                "version": util.API_VERSION_1,
+            },
+        )
+        responses.add(
+            responses.POST, "http://www.foo.com/foo?api_key=KEY&api_secret=SECRET"
+        )
+        component.post_request("foo")
+
+    @responses.activate
+    def test_post_request_includes_config_details_in_data_when_there_is_data(self):
+        component = components.base.BaseComponent(
+            base_uri="http://www.foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
+        )
+        responses.add(
+            responses.POST,
+            "http://www.foo.com/foo?foo=bar&api_key=KEY&api_secret=SECRET",
+        )
+        component.post_request("foo", params={"foo": "bar"})
+
+    @responses.activate
+    def test_v2_post_request_passes_jwt_token(self):
+        component = components.base.BaseComponent(
+            base_uri="http://www.foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
                 "token": 42,
             },
         )
-        component.post_request("foo")
-        mock_post_request.assert_called_with(
-            "foo",
-            params={},
-            data=None,
-            headers={"Authorization": "Bearer 42", "Content-Type": "application/json"},
-            cookies=None,
+        responses.add(
+            responses.POST,
+            "http://www.foo.com/foo",
+            headers={"Authorization": "Bearer 42"},
         )
+        component.post_request("foo")
 
 
 if __name__ == "__main__":

--- a/tests/zoomus/components/test_base.py
+++ b/tests/zoomus/components/test_base.py
@@ -26,7 +26,11 @@ class BaseComponentTestCase(unittest.TestCase):
         )
         component.post_request("foo")
         mock_post_request.assert_called_with(
-            "foo", params=component.config, data=None, headers=None, cookies=None
+            "foo",
+            params={"api_key": "KEY", "api_secret": "SECRET"},
+            data=None,
+            headers=None,
+            cookies=None,
         )
 
     def test_post_request_includes_config_details_in_data_when_there_is_data(
@@ -38,11 +42,12 @@ class BaseComponentTestCase(unittest.TestCase):
         )
         component.post_request("foo", params={"foo": "bar"})
 
-        params = {"foo": "bar"}
-        params.update(component.config)
-
         mock_post_request.assert_called_with(
-            "foo", params=params, data=None, headers=None, cookies=None
+            "foo",
+            params={"foo": "bar", "api_key": "KEY", "api_secret": "SECRET"},
+            data=None,
+            headers=None,
+            cookies=None,
         )
 
     def test_v2_post_request_passes_jwt_token(self, mock_post_request):

--- a/tests/zoomus/components/user/test_create.py
+++ b/tests/zoomus/components/user/test_create.py
@@ -41,8 +41,9 @@ class CreateV2TestCase(unittest.TestCase):
 
     @responses.activate
     def test_can_create(self):
-        responses.add(responses.POST, "http://foo.com/users?foo=bar")
-        self.component.create(foo="bar")
+        responses.add(responses.POST, "http://foo.com/users")
+        response = self.component.create(foo="bar")
+        self.assertEqual(response.request.body, '{"foo": "bar"}')
 
 
 if __name__ == "__main__":

--- a/tests/zoomus/components/user/test_create.py
+++ b/tests/zoomus/components/user/test_create.py
@@ -1,11 +1,7 @@
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
-from zoomus import components
+from zoomus import components, util
+import responses
 
 
 def suite():
@@ -18,29 +14,35 @@ def suite():
 class CreateV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.user.UserComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
+    @responses.activate
     def test_can_create(self):
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            self.component.create()
-
-            mock_post_request.assert_called_with("/user/create", params={})
+        responses.add(responses.POST, "http://foo.com/user/create")
+        self.component.create()
 
 
 class CreateV2TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.user.UserComponentV2(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
-    def test_can_create(self, mock_post_request):
+    @responses.activate
+    def test_can_create(self):
+        responses.add(responses.POST, "http://foo.com/users?foo=bar")
         self.component.create(foo="bar")
-        mock_post_request.assert_called_with("/users", data={"foo": "bar"})
 
 
 if __name__ == "__main__":

--- a/tests/zoomus/components/user/test_cust_create.py
+++ b/tests/zoomus/components/user/test_cust_create.py
@@ -1,11 +1,7 @@
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
-from zoomus import components
+from zoomus import components, util
+import responses
 
 
 def suite():
@@ -18,29 +14,29 @@ def suite():
 class CustCreateV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.user.UserComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
-    def test_can_get_by_email(self):
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            self.component.cust_create(type="foo", email="a@b.com")
-
-            mock_post_request.assert_called_with(
-                "/user/custcreate", params={"type": "foo", "email": "a@b.com"}
-            )
+    @responses.activate
+    def test_can_create_by_email(self):
+        responses.add(
+            responses.POST,
+            "http://foo.com/user/custcreate?type=foo&email=a@b.com&api_key=KEY&api_secret=SECRET",
+        )
+        self.component.cust_create(type="foo", email="a@b.com")
 
     def test_requires_type(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegexp(ValueError, "'type' must be set"):
             self.component.cust_create()
-            self.assertEqual(context.exception.message, "'type' must be set")
 
     def test_requires_email(self):
-        with self.assertRaises(ValueError) as context:
-            self.component.cust_create()
-            self.assertEqual(context.exception.message, "'email' must be set")
+        with self.assertRaisesRegexp(ValueError, "'email' must be set"):
+            self.component.cust_create(type="foo")
 
 
 if __name__ == "__main__":

--- a/tests/zoomus/components/user/test_delete.py
+++ b/tests/zoomus/components/user/test_delete.py
@@ -1,11 +1,7 @@
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
-from zoomus import components
+from zoomus import components, util
+import responses
 
 
 def suite():
@@ -18,34 +14,42 @@ def suite():
 class DeleteV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.user.UserComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
+    @responses.activate
     def test_can_delete(self):
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            self.component.delete(id="ID")
-
-            mock_post_request.assert_called_with("/user/delete", params={"id": "ID"})
+        responses.add(
+            responses.POST,
+            "http://foo.com/user/delete?id=42&api_key=KEY&api_secret=SECRET",
+        )
+        self.component.delete(id="42")
 
     def test_requires_id(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
             self.component.delete()
-            self.assertEqual(context.exception.message, "'id' must be set")
 
 
 class DeleteV2TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.user.UserComponentV2(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "delete_request", return_value=True)
-    def test_can_delete(self, mock_delete_request):
-        self.component.delete(id="ID")
-        mock_delete_request.assert_called_with("/users/ID", params={"id": "ID"})
+    @responses.activate
+    def test_can_delete(self):
+        responses.add(responses.DELETE, "http://foo.com/users/42?id=42")
+        self.component.delete(id="42")
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):

--- a/tests/zoomus/components/user/test_get.py
+++ b/tests/zoomus/components/user/test_get.py
@@ -1,11 +1,7 @@
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
-from zoomus import components
+from zoomus import components, util
+import responses
 
 
 def suite():
@@ -18,17 +14,21 @@ def suite():
 class GetV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.user.UserComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
+    @responses.activate
     def test_can_get(self):
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            self.component.get(id="ID")
-
-            mock_post_request.assert_called_with("/user/get", params={"id": "ID"})
+        responses.add(
+            responses.POST,
+            "http://foo.com/user/get?id=42&api_key=KEY&api_secret=SECRET",
+        )
+        self.component.get(id="42")
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):
@@ -38,13 +38,18 @@ class GetV1TestCase(unittest.TestCase):
 class GetV2TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.user.UserComponentV2(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
-    def test_can_get(self, mock_get_request):
-        self.component.get(id="ID")
-        mock_get_request.assert_called_with("/users/ID", params={"id": "ID"})
+    @responses.activate
+    def test_can_get(self):
+        responses.add(responses.GET, "http://foo.com/users/42?id=42")
+        self.component.get(id="42")
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):

--- a/tests/zoomus/components/user/test_get_by_email.py
+++ b/tests/zoomus/components/user/test_get_by_email.py
@@ -1,11 +1,7 @@
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
-from zoomus import components
+from zoomus import components, util
+import responses
 
 
 def suite():
@@ -18,29 +14,29 @@ def suite():
 class GetByEmailV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.user.UserComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
+    @responses.activate
     def test_can_get_by_email(self):
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            self.component.get_by_email(email="a@b.com", login_type="foo")
-
-            mock_post_request.assert_called_with(
-                "/user/getbyemail", params={"email": "a@b.com", "login_type": "foo"}
-            )
+        responses.add(
+            responses.POST,
+            "http://foo.com/user/getbyemail?email=a@b.com&login_type=foo&api_key=KEY&api_secret=SECRET",
+        )
+        self.component.get_by_email(email="a@b.com", login_type="foo")
 
     def test_requires_email(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegexp(ValueError, "'email' must be set"):
             self.component.get_by_email()
-            self.assertEqual(context.exception.message, "'email' must be set")
 
     def test_requires_login_type(self):
-        with self.assertRaises(ValueError) as context:
-            self.component.get_by_email()
-            self.assertEqual(context.exception.message, "'login_type' must be set")
+        with self.assertRaisesRegexp(ValueError, "'login_type' must be set"):
+            self.component.get_by_email(email="a@b.com")
 
 
 if __name__ == "__main__":

--- a/tests/zoomus/components/user/test_list.py
+++ b/tests/zoomus/components/user/test_list.py
@@ -1,11 +1,7 @@
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
-from zoomus import components
+from zoomus import components, util
+import responses
 
 
 def suite():
@@ -18,30 +14,37 @@ def suite():
 class ListV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.user.UserComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
+    @responses.activate
     def test_can_list(self):
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            self.component.list()
-
-            mock_post_request.assert_called_with("/user/list", params={})
+        responses.add(
+            responses.POST, "http://foo.com/user/list?api_key=KEY&api_secret=SECRET"
+        )
+        self.component.list()
 
 
 class ListV2TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.user.UserComponentV2(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
-    def test_can_list(self, mock_get_request):
+    @responses.activate
+    def test_can_list(self):
+        responses.add(responses.GET, "http://foo.com/users")
         self.component.list()
-
-        mock_get_request.assert_called_with("/users", params={})
 
 
 if __name__ == "__main__":

--- a/tests/zoomus/components/user/test_pending.py
+++ b/tests/zoomus/components/user/test_pending.py
@@ -1,11 +1,7 @@
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
-from zoomus import components
+from zoomus import components, util
+import responses
 
 
 def suite():
@@ -18,17 +14,20 @@ def suite():
 class PendingV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.user.UserComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
+    @responses.activate
     def test_can_end(self):
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            self.component.pending()
-
-            mock_post_request.assert_called_with("/user/pending", params={})
+        responses.add(
+            responses.POST, "http://foo.com/user/pending?api_key=KEY&api_secret=SECRET"
+        )
+        self.component.pending()
 
 
 if __name__ == "__main__":

--- a/tests/zoomus/components/user/test_update.py
+++ b/tests/zoomus/components/user/test_update.py
@@ -48,8 +48,9 @@ class UpdateV2TestCase(unittest.TestCase):
 
     @responses.activate
     def test_can_update(self):
-        responses.add(responses.PATCH, "http://foo.com/users/42?id=42")
-        self.component.update(id="42")
+        responses.add(responses.PATCH, "http://foo.com/users/42")
+        response = self.component.update(id="42")
+        self.assertEqual(response.request.body, '{"id": "42"}')
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):

--- a/tests/zoomus/components/user/test_update.py
+++ b/tests/zoomus/components/user/test_update.py
@@ -1,11 +1,7 @@
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
-from zoomus import components
+from zoomus import components, util
+import responses
 
 
 def suite():
@@ -18,34 +14,42 @@ def suite():
 class UpdateV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.user.UserComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
+    @responses.activate
     def test_can_update(self):
-        with patch.object(
-            components.base.BaseComponent, "post_request", return_value=True
-        ) as mock_post_request:
-
-            self.component.update(id="ID")
-
-            mock_post_request.assert_called_with("/user/update", params={"id": "ID"})
+        responses.add(
+            responses.POST,
+            "http://foo.com/user/update?id=42&api_key=KEY&api_secret=SECRET",
+        )
+        self.component.update(id="42")
 
     def test_requires_id(self):
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
             self.component.update()
-            self.assertEqual(context.exception.message, "'id' must be set")
 
 
 class UpdateV2TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.user.UserComponentV2(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "patch_request", return_value=True)
-    def test_can_update(self, mock_patch_request):
-        self.component.update(id="ID")
-        mock_patch_request.assert_called_with("/users/ID", data={"id": "ID"})
+    @responses.activate
+    def test_can_update(self):
+        responses.add(responses.PATCH, "http://foo.com/users/42?id=42")
+        self.component.update(id="42")
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):

--- a/tests/zoomus/components/webinar/test_absentees.py
+++ b/tests/zoomus/components/webinar/test_absentees.py
@@ -1,12 +1,8 @@
 from datetime import datetime
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
 from zoomus import components
+import responses
 
 
 def suite():
@@ -22,13 +18,10 @@ class AbsenteesV2TestCase(unittest.TestCase):
             base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
-    def test_can_absentees(self, mock_get_request):
+    @responses.activate
+    def test_can_absentees(self):
+        responses.add(responses.GET, "http://foo.com/past_webinars/ID/absentees?id=ID")
         self.component.get_absentees(id="ID")
-
-        mock_get_request.assert_called_with(
-            "/past_webinars/ID/absentees", params={"id": "ID"}
-        )
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):

--- a/tests/zoomus/components/webinar/test_create.py
+++ b/tests/zoomus/components/webinar/test_create.py
@@ -63,8 +63,9 @@ class CreateV2TestCase(unittest.TestCase):
 
     @responses.activate
     def test_can_create(self):
-        responses.add(responses.POST, "http://foo.com/users/42/webinars?user_id=42")
-        self.component.create(user_id="42")
+        responses.add(responses.POST, "http://foo.com/users/42/webinars")
+        response = self.component.create(user_id="42")
+        self.assertEqual(response.request.body, '{"user_id": "42"}')
 
     def test_requires_user_id(self):
         with self.assertRaisesRegexp(ValueError, "'user_id' must be set"):

--- a/tests/zoomus/components/webinar/test_delete.py
+++ b/tests/zoomus/components/webinar/test_delete.py
@@ -1,11 +1,7 @@
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
-from zoomus import components
+from zoomus import components, util
+import responses
 
 
 def suite():
@@ -18,16 +14,21 @@ def suite():
 class DeleteV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.webinar.WebinarComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
-    def test_can_delete(self, mock_post_request):
+    @responses.activate
+    def test_can_delete(self):
+        responses.add(
+            responses.POST,
+            "http://foo.com/webinar/delete?id=ID&host_id=ID&api_key=KEY&api_secret=SECRET",
+        )
         self.component.delete(id="ID", host_id="ID")
-
-        mock_post_request.assert_called_with(
-            "/webinar/delete", params={"id": "ID", "host_id": "ID"}
-        )
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):
@@ -41,14 +42,18 @@ class DeleteV1TestCase(unittest.TestCase):
 class DeleteV2TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.webinar.WebinarComponentV2(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "delete_request", return_value=True)
-    def test_can_delete(self, mock_delete_request):
-        self.component.delete(id="ID")
-
-        mock_delete_request.assert_called_with("/webinars/ID", params={"id": "ID"})
+    @responses.activate
+    def test_can_delete(self):
+        responses.add(responses.DELETE, "http://foo.com/webinars/42?id=42")
+        self.component.delete(id="42")
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):

--- a/tests/zoomus/components/webinar/test_end.py
+++ b/tests/zoomus/components/webinar/test_end.py
@@ -52,8 +52,9 @@ class EndV2TestCase(unittest.TestCase):
 
     @responses.activate
     def test_can_end(self):
-        responses.add(responses.PUT, "http://foo.com/webinars/42/status?status=end")
-        self.component.end(id="42")
+        responses.add(responses.PUT, "http://foo.com/webinars/42/status")
+        response = self.component.end(id="42")
+        self.assertEqual(response.request.body, '{"status": "end"}')
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):

--- a/tests/zoomus/components/webinar/test_end.py
+++ b/tests/zoomus/components/webinar/test_end.py
@@ -1,11 +1,7 @@
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
-from zoomus import components
+from zoomus import components, util
+import responses
 
 
 def suite():
@@ -18,16 +14,21 @@ def suite():
 class EndV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.webinar.WebinarComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
-    def test_can_end(self, mock_post_request):
+    @responses.activate
+    def test_can_end(self):
+        responses.add(
+            responses.POST,
+            "http://foo.com/webinar/end?id=ID&host_id=ID&api_key=KEY&api_secret=SECRET",
+        )
         self.component.end(id="ID", host_id="ID")
-
-        mock_post_request.assert_called_with(
-            "/webinar/end", params={"id": "ID", "host_id": "ID"}
-        )
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):
@@ -41,16 +42,18 @@ class EndV1TestCase(unittest.TestCase):
 class EndV2TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.webinar.WebinarComponentV2(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "put_request", return_value=True)
-    def test_can_end(self, mock_put_request):
-        self.component.end(id="ID")
-
-        mock_put_request.assert_called_with(
-            "/webinars/ID/status", data={"status": "end"}
-        )
+    @responses.activate
+    def test_can_end(self):
+        responses.add(responses.PUT, "http://foo.com/webinars/42/status?status=end")
+        self.component.end(id="42")
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):

--- a/tests/zoomus/components/webinar/test_get.py
+++ b/tests/zoomus/components/webinar/test_get.py
@@ -1,11 +1,7 @@
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
-from zoomus import components
+from zoomus import components, util
+import responses
 
 
 def suite():
@@ -18,16 +14,21 @@ def suite():
 class GetV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.webinar.WebinarComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
-    def test_can_end(self, mock_post_request):
+    @responses.activate
+    def test_can_get(self):
+        responses.add(
+            responses.POST,
+            "http://foo.com/webinar/get?id=ID&host_id=ID&api_key=KEY&api_secret=SECRET",
+        )
         self.component.get(id="ID", host_id="ID")
-
-        mock_post_request.assert_called_with(
-            "/webinar/get", params={"id": "ID", "host_id": "ID"}
-        )
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):
@@ -41,14 +42,18 @@ class GetV1TestCase(unittest.TestCase):
 class GetV2TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.webinar.WebinarComponentV2(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
-    def test_can_end(self, mock_get_request):
-        self.component.get(id="ID")
-
-        mock_get_request.assert_called_with("/webinars/ID", params={"id": "ID"})
+    @responses.activate
+    def test_can_get(self):
+        responses.add(responses.GET, "http://foo.com/webinars/42?id=42")
+        self.component.get(id="42")
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):

--- a/tests/zoomus/components/webinar/test_list.py
+++ b/tests/zoomus/components/webinar/test_list.py
@@ -1,12 +1,8 @@
 import datetime
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
 from zoomus import components, util
+import responses
 
 
 def suite():
@@ -19,50 +15,54 @@ def suite():
 class ListV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.webinar.WebinarComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
-    def test_can_list(self, mock_post_request):
+    @responses.activate
+    def test_can_list(self):
+        responses.add(
+            responses.POST,
+            "http://foo.com/webinar/list?host_id=ID&api_key=KEY&api_secret=SECRET",
+        )
         self.component.list(host_id="ID")
-
-        mock_post_request.assert_called_with("/webinar/list", params={"host_id": "ID"})
 
     def test_requires_host_id(self):
         with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
             self.component.list()
 
-    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
-    def test_does_convert_startime_to_str_if_datetime(self, mock_post_request):
-        start_time = datetime.datetime.utcnow()
+    @responses.activate
+    def test_does_convert_startime_to_str_if_datetime(self):
+        start_time = datetime.datetime(1969, 1, 1, 1, 1)
+        responses.add(
+            responses.POST,
+            "http://foo.com/webinar/list?host_id=ID&topic=TOPIC&type=TYPE&api_key=KEY&api_secret=SECRET"
+            "&start_time=1969-01-01T01%3A01%3A00Z",
+        )
         self.component.list(
             host_id="ID", topic="TOPIC", type="TYPE", start_time=start_time
-        )
-
-        mock_post_request.assert_called_with(
-            "/webinar/list",
-            params={
-                "host_id": "ID",
-                "topic": "TOPIC",
-                "type": "TYPE",
-                "start_time": util.date_to_str(start_time),
-            },
         )
 
 
 class ListV2TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.webinar.WebinarComponentV2(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
-    def test_can_list(self, mock_get_request):
-        self.component.list(user_id="ID")
-
-        mock_get_request.assert_called_with(
-            "/users/ID/webinars", params={"user_id": "ID"}
-        )
+    @responses.activate
+    def test_can_list(self):
+        responses.add(responses.GET, "http://foo.com/users/42/webinars?user_id=42")
+        self.component.list(user_id="42")
 
     def test_requires_user_id(self):
         with self.assertRaisesRegexp(ValueError, "'user_id' must be set"):

--- a/tests/zoomus/components/webinar/test_register.py
+++ b/tests/zoomus/components/webinar/test_register.py
@@ -82,11 +82,14 @@ class RegisterV2TestCase(unittest.TestCase):
     @responses.activate
     def test_can_register(self):
         responses.add(
-            responses.POST,
-            "http://foo.com/webinars/42/registrants?id=42&email=foo@bar.com&first_name=Foo&last_name=Bar",
+            responses.POST, "http://foo.com/webinars/42/registrants",
         )
-        self.component.register(
+        response = self.component.register(
             id="42", email="foo@bar.com", first_name="Foo", last_name="Bar"
+        )
+        self.assertEqual(
+            response.request.body,
+            '{"id": "42", "email": "foo@bar.com", "first_name": "Foo", "last_name": "Bar"}',
         )
 
     def test_requires_id(self):

--- a/tests/zoomus/components/webinar/test_registrants.py
+++ b/tests/zoomus/components/webinar/test_registrants.py
@@ -1,12 +1,8 @@
 from datetime import datetime
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
 from zoomus import components
+import responses
 
 
 def suite():
@@ -22,13 +18,10 @@ class RegisterantsV2TestCase(unittest.TestCase):
             base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
         )
 
-    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
-    def test_can_registrants(self, mock_get_request):
+    @responses.activate
+    def test_can_registrants(self):
+        responses.add(responses.GET, "http://foo.com/webinars/ID/registrants?id=ID")
         self.component.get_registrants(id="ID")
-
-        mock_get_request.assert_called_with(
-            "/webinars/ID/registrants", params={"id": "ID"}
-        )
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):

--- a/tests/zoomus/components/webinar/test_update.py
+++ b/tests/zoomus/components/webinar/test_update.py
@@ -63,8 +63,9 @@ class UpdateV2TestCase(unittest.TestCase):
 
     @responses.activate
     def test_can_update(self):
-        responses.add(responses.PATCH, "http://foo.com/webinars/42?id=42")
-        self.component.update(id="42")
+        responses.add(responses.PATCH, "http://foo.com/webinars/42")
+        response = self.component.update(id="42")
+        self.assertEqual(response.request.body, '{"id": "42"}')
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):

--- a/tests/zoomus/components/webinar/test_update.py
+++ b/tests/zoomus/components/webinar/test_update.py
@@ -1,12 +1,8 @@
-from datetime import datetime
+import datetime
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
-from zoomus import components
+from zoomus import components, util
+import responses
 
 
 def suite():
@@ -19,16 +15,21 @@ def suite():
 class UpdateV1TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.webinar.WebinarComponent(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
-    def test_can_update(self, mock_post_request):
+    @responses.activate
+    def test_can_update(self):
+        responses.add(
+            responses.POST,
+            "http://foo.com/webinar/update?id=ID&host_id=ID&api_key=KEY&api_secret=SECRET",
+        )
         self.component.update(id="ID", host_id="ID")
-
-        mock_post_request.assert_called_with(
-            "/webinar/update", params={"id": "ID", "host_id": "ID"}
-        )
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):
@@ -38,30 +39,32 @@ class UpdateV1TestCase(unittest.TestCase):
         with self.assertRaisesRegexp(ValueError, "'host_id' must be set"):
             self.component.update(id="ID")
 
-    @patch.object(components.base.BaseComponent, "post_request", return_value=True)
-    def test_start_time_gets_transformed(self, mock_post_request):
-        self.component.update(id="42", host_id="HOST", start_time=datetime(1969, 1, 1))
-        mock_post_request.assert_called_with(
-            "/webinar/update",
-            params={
-                "id": "42",
-                "host_id": "HOST",
-                "start_time": "1969-01-01T00:00:00Z",
-            },
+    @responses.activate
+    def test_start_time_gets_transformed(self):
+        start_time = datetime.datetime(1969, 1, 1, 1, 1)
+        responses.add(
+            responses.POST,
+            "http://foo.com/webinar/update?id=42&host_id=HOST"
+            "&start_time=1969-01-01T01%3A01%3A00Z&api_key=KEY&api_secret=SECRET",
         )
+        self.component.update(id="42", host_id="HOST", start_time=start_time)
 
 
 class UpdateV2TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.webinar.WebinarComponentV2(
-            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_1,
+            },
         )
 
-    @patch.object(components.base.BaseComponent, "patch_request", return_value=True)
-    def test_can_update(self, mock_patch_request):
-        self.component.update(id="ID")
-
-        mock_patch_request.assert_called_with("/webinars/ID", data={"id": "ID"})
+    @responses.activate
+    def test_can_update(self):
+        responses.add(responses.PATCH, "http://foo.com/webinars/42?id=42")
+        self.component.update(id="42")
 
     def test_requires_id(self):
         with self.assertRaisesRegexp(ValueError, "'id' must be set"):

--- a/tests/zoomus/test_client.py
+++ b/tests/zoomus/test_client.py
@@ -1,11 +1,11 @@
 import unittest
 
+from zoomus import components, ZoomClient, util
+
 try:
     from unittest import mock
 except ImportError:
-    import mock
-
-from zoomus import API_VERSION_2, components, ZoomClient, util
+    import mock  # type: ignore
 
 
 def suite():
@@ -25,7 +25,7 @@ class ZoomClientTestCase(unittest.TestCase):
                 "api_secret": "SECRET",
                 "data_type": "json",
                 "token": util.generate_jwt("KEY", "SECRET"),
-                "version": API_VERSION_2,
+                "version": util.API_VERSION_2,
             },
         )
 
@@ -72,7 +72,7 @@ class ZoomClientTestCase(unittest.TestCase):
 
     def test_api_version_defaults_to_2(self):
         client = ZoomClient("KEY", "SECRET")
-        self.assertEqual(client.config["version"], API_VERSION_2)
+        self.assertEqual(client.config["version"], util.API_VERSION_2)
 
     def test_can_get_api_key(self):
         client = ZoomClient("KEY", "SECRET")

--- a/tests/zoomus/test_util.py
+++ b/tests/zoomus/test_util.py
@@ -2,12 +2,8 @@ import datetime
 import json
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
-from zoomus import API_VERSION_1, util
+from zoomus import util
+import responses
 
 
 def suite():
@@ -81,397 +77,208 @@ class ApiClientTestCase(unittest.TestCase):
         client = util.ApiClient(base_uri="http://www.foo.com")
         self.assertEqual(client.url_for("bar/"), "http://www.foo.com/bar")
 
-    @patch("requests.get")
-    def test_can_get_request(self, mocked_get):
-
-        mocked_get.side_effect = lambda *args, **kwargs: True
-
+    @responses.activate
+    def test_can_get_request(self):
+        responses.add(responses.GET, "http://www.foo.com/endpoint")
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.get_request("endpoint")
 
-        mocked_get.assert_called_with(
-            client.url_for("endpoint"),
-            params=None,
-            headers=None,
-            timeout=client.timeout,
-        )
-
-    @patch("requests.get")
-    def test_can_get_request_with_params(self, mocked_get):
-
-        mocked_get.side_effect = lambda *args, **kwargs: True
-
+    @responses.activate
+    def test_can_get_request_with_params(self):
+        responses.add(responses.GET, "http://www.foo.com/endpoint?foo=bar")
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.get_request("endpoint", params={"foo": "bar"})
 
-        mocked_get.assert_called_with(
-            client.url_for("endpoint"),
-            params={"foo": "bar"},
-            headers=None,
-            timeout=client.timeout,
+    @responses.activate
+    def test_can_get_request_with_headers(self):
+        responses.add(
+            responses.GET, "http://www.foo.com/endpoint", headers={"foo": "bar"}
         )
-
-    @patch("requests.get")
-    def test_can_get_request_with_headers(self, mocked_get):
-
-        mocked_get.side_effect = lambda *args, **kwargs: True
-
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.get_request("endpoint", headers={"foo": "bar"})
 
-        mocked_get.assert_called_with(
-            client.url_for("endpoint"),
-            params=None,
-            headers={"foo": "bar"},
-            timeout=client.timeout,
-        )
-
-    @patch("requests.post")
-    def test_can_post_request(self, mocked_post):
-
-        mocked_post.side_effect = lambda *args, **kwargs: True
+    @responses.activate
+    def test_can_post_request(self):
+        responses.add(responses.POST, "http://www.foo.com/endpoint")
 
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.post_request("endpoint")
 
-        mocked_post.assert_called_with(
-            client.url_for("endpoint"),
-            params=None,
-            data=None,
-            headers=None,
-            cookies=None,
-            timeout=client.timeout,
-        )
-
-    @patch("requests.post")
-    def test_can_post_request_with_params(self, mocked_post):
-
-        mocked_post.side_effect = lambda *args, **kwargs: True
-
+    @responses.activate
+    def test_can_post_request_with_params(self):
+        responses.add(responses.POST, "http://www.foo.com/endpoint?foo=bar")
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.post_request("endpoint", params={"foo": "bar"})
 
-        mocked_post.assert_called_with(
-            client.url_for("endpoint"),
-            params={"foo": "bar"},
-            data=None,
-            headers=None,
-            cookies=None,
-            timeout=client.timeout,
-        )
-
-    @patch("requests.post")
-    def test_can_post_request_with_dict_data(self, mocked_post):
-
-        mocked_post.side_effect = lambda *args, **kwargs: True
-
+    @responses.activate
+    def test_can_post_request_with_dict_data(self):
+        responses.add(responses.POST, "http://www.foo.com/endpoint")
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.post_request("endpoint", data={"foo": "bar"})
+        self.assertEqual(responses.calls[0].request.body, '{"foo": "bar"}')
 
-        mocked_post.assert_called_with(
-            client.url_for("endpoint"),
-            params=None,
-            data=json.dumps({"foo": "bar"}),
-            headers=None,
-            cookies=None,
-            timeout=client.timeout,
-        )
-
-    @patch("requests.post")
-    def test_can_post_request_with_json_data(self, mocked_post):
-
-        mocked_post.side_effect = lambda *args, **kwargs: True
-
+    @responses.activate
+    def test_can_post_request_with_json_data(self):
+        responses.add(responses.POST, "http://www.foo.com/endpoint")
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.post_request("endpoint", data=json.dumps({"foo": "bar"}))
+        self.assertEqual(responses.calls[0].request.body, '{"foo": "bar"}')
 
-        mocked_post.assert_called_with(
-            client.url_for("endpoint"),
-            params=None,
-            data=json.dumps({"foo": "bar"}),
-            headers=None,
-            cookies=None,
-            timeout=client.timeout,
-        )
-
-    @patch("requests.post")
-    def test_can_post_request_with_headers(self, mocked_post):
-
-        mocked_post.side_effect = lambda *args, **kwargs: True
-
+    @responses.activate
+    def test_can_post_request_with_headers(self):
+        responses.add(responses.POST, "http://www.foo.com/endpoint")
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.post_request("endpoint", headers={"foo": "bar"})
-
-        mocked_post.assert_called_with(
-            client.url_for("endpoint"),
-            params=None,
-            data=None,
-            headers={"foo": "bar"},
-            cookies=None,
-            timeout=client.timeout,
+        expected_headers = {"foo": "bar"}
+        actual_headers = responses.calls[0].request.headers
+        self.assertTrue(
+            set(expected_headers.items()).issubset(set(actual_headers.items()))
         )
 
-    @patch("requests.post")
-    def test_can_post_request_with_cookies(self, mocked_post):
-
-        mocked_post.side_effect = lambda *args, **kwargs: True
-
+    @responses.activate
+    def test_can_post_request_with_cookies(self):
+        responses.add(responses.POST, "http://www.foo.com/endpoint")
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.post_request("endpoint", cookies={"foo": "bar"})
-
-        mocked_post.assert_called_with(
-            client.url_for("endpoint"),
-            params=None,
-            data=None,
-            headers=None,
-            cookies={"foo": "bar"},
-            timeout=client.timeout,
+        expected_headers = {"Cookie": "foo=bar"}
+        actual_headers = responses.calls[0].request.headers
+        self.assertTrue(
+            set(expected_headers.items()).issubset(set(actual_headers.items()))
         )
 
-    @patch("requests.patch")
-    def test_can_patch_request(self, mocked_patch):
-
-        mocked_patch.side_effect = lambda *args, **kwargs: True
-
+    @responses.activate
+    def test_can_patch_request(self):
+        responses.add(responses.PATCH, "http://www.foo.com/endpoint")
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.patch_request("endpoint")
 
-        mocked_patch.assert_called_with(
-            client.url_for("endpoint"),
-            params=None,
-            data=None,
-            headers=None,
-            cookies=None,
-            timeout=client.timeout,
-        )
-
-    @patch("requests.patch")
-    def test_can_patch_request_with_params(self, mocked_patch):
-
-        mocked_patch.side_effect = lambda *args, **kwargs: True
-
+    @responses.activate
+    def test_can_patch_request_with_params(self):
+        responses.add(responses.PATCH, "http://www.foo.com/endpoint?foo=bar")
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.patch_request("endpoint", params={"foo": "bar"})
 
-        mocked_patch.assert_called_with(
-            client.url_for("endpoint"),
-            params={"foo": "bar"},
-            data=None,
-            headers=None,
-            cookies=None,
-            timeout=client.timeout,
-        )
-
-    @patch("requests.patch")
-    def test_can_patch_request_with_dict_data(self, mocked_patch):
-
-        mocked_patch.side_effect = lambda *args, **kwargs: True
-
+    @responses.activate
+    def test_can_patch_request_with_dict_data(self):
+        responses.add(responses.PATCH, "http://www.foo.com/endpoint")
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.patch_request("endpoint", data={"foo": "bar"})
+        self.assertEqual(responses.calls[0].request.body, '{"foo": "bar"}')
 
-        mocked_patch.assert_called_with(
-            client.url_for("endpoint"),
-            params=None,
-            data=json.dumps({"foo": "bar"}),
-            headers=None,
-            cookies=None,
-            timeout=client.timeout,
-        )
-
-    @patch("requests.patch")
-    def test_can_patch_request_with_json_data(self, mocked_patch):
-
-        mocked_patch.side_effect = lambda *args, **kwargs: True
-
+    @responses.activate
+    def test_can_patch_request_with_json_data(self):
+        responses.add(responses.PATCH, "http://www.foo.com/endpoint")
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.patch_request("endpoint", data=json.dumps({"foo": "bar"}))
+        self.assertEqual(responses.calls[0].request.body, '{"foo": "bar"}')
 
-        mocked_patch.assert_called_with(
-            client.url_for("endpoint"),
-            params=None,
-            data=json.dumps({"foo": "bar"}),
-            headers=None,
-            cookies=None,
-            timeout=client.timeout,
-        )
-
-    @patch("requests.patch")
-    def test_can_patch_request_with_headers(self, mocked_patch):
-
-        mocked_patch.side_effect = lambda *args, **kwargs: True
-
+    @responses.activate
+    def test_can_patch_request_with_headers(self):
+        responses.add(responses.PATCH, "http://www.foo.com/endpoint")
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.patch_request("endpoint", headers={"foo": "bar"})
-
-        mocked_patch.assert_called_with(
-            client.url_for("endpoint"),
-            params=None,
-            data=None,
-            headers={"foo": "bar"},
-            cookies=None,
-            timeout=client.timeout,
+        expected_headers = {"foo": "bar"}
+        actual_headers = responses.calls[0].request.headers
+        self.assertTrue(
+            set(expected_headers.items()).issubset(set(actual_headers.items()))
         )
 
-    @patch("requests.patch")
-    def test_can_patch_request_with_cookies(self, mocked_patch):
-
-        mocked_patch.side_effect = lambda *args, **kwargs: True
-
+    @responses.activate
+    def test_can_patch_request_with_cookies(self):
+        responses.add(responses.PATCH, "http://www.foo.com/endpoint")
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.patch_request("endpoint", cookies={"foo": "bar"})
-
-        mocked_patch.assert_called_with(
-            client.url_for("endpoint"),
-            params=None,
-            data=None,
-            headers=None,
-            cookies={"foo": "bar"},
-            timeout=client.timeout,
+        expected_headers = {"Cookie": "foo=bar"}
+        actual_headers = responses.calls[0].request.headers
+        self.assertTrue(
+            set(expected_headers.items()).issubset(set(actual_headers.items()))
         )
 
-    @patch("requests.delete")
-    def test_can_delete_request(self, mocked_delete):
-
-        mocked_delete.side_effect = lambda *args, **kwargs: True
-
+    @responses.activate
+    def test_can_delete_request(self):
+        responses.add(responses.DELETE, "http://www.foo.com/endpoint")
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.delete_request("endpoint")
 
-        mocked_delete.assert_called_with(
-            client.url_for("endpoint"),
-            params=None,
-            data=None,
-            headers=None,
-            cookies=None,
-            timeout=client.timeout,
-        )
-
-    @patch("requests.delete")
-    def test_can_delete_request_with_params(self, mocked_delete):
-
-        mocked_delete.side_effect = lambda *args, **kwargs: True
-
+    @responses.activate
+    def test_can_delete_request_with_params(self):
+        responses.add(responses.DELETE, "http://www.foo.com/endpoint?foo=bar")
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.delete_request("endpoint", params={"foo": "bar"})
 
-        mocked_delete.assert_called_with(
-            client.url_for("endpoint"),
-            params={"foo": "bar"},
-            data=None,
-            headers=None,
-            cookies=None,
-            timeout=client.timeout,
-        )
-
-    @patch("requests.delete")
-    def test_can_delete_request_with_dict_data(self, mocked_delete):
-
-        mocked_delete.side_effect = lambda *args, **kwargs: True
-
+    @responses.activate
+    def test_can_delete_request_with_dict_data(self):
+        responses.add(responses.DELETE, "http://www.foo.com/endpoint")
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.delete_request("endpoint", data={"foo": "bar"})
+        self.assertEqual(responses.calls[0].request.body, '{"foo": "bar"}')
 
-        mocked_delete.assert_called_with(
-            client.url_for("endpoint"),
-            params=None,
-            data=json.dumps({"foo": "bar"}),
-            headers=None,
-            cookies=None,
-            timeout=client.timeout,
-        )
-
-    @patch("requests.delete")
-    def test_can_delete_request_with_json_data(self, mocked_delete):
-
-        mocked_delete.side_effect = lambda *args, **kwargs: True
-
+    @responses.activate
+    def test_can_delete_request_with_json_data(self):
+        responses.add(responses.DELETE, "http://www.foo.com/endpoint")
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.delete_request("endpoint", data=json.dumps({"foo": "bar"}))
+        self.assertEqual(responses.calls[0].request.body, '{"foo": "bar"}')
 
-        mocked_delete.assert_called_with(
-            client.url_for("endpoint"),
-            params=None,
-            data=json.dumps({"foo": "bar"}),
-            headers=None,
-            cookies=None,
-            timeout=client.timeout,
+    @responses.activate
+    def test_can_delete_request_with_headers(self):
+        responses.add(
+            responses.DELETE, "http://www.foo.com/endpoint", headers={"foo": "bar"}
         )
-
-    @patch("requests.delete")
-    def test_can_delete_request_with_headers(self, mocked_delete):
-
-        mocked_delete.side_effect = lambda *args, **kwargs: True
-
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.delete_request("endpoint", headers={"foo": "bar"})
 
-        mocked_delete.assert_called_with(
-            client.url_for("endpoint"),
-            params=None,
-            data=None,
-            headers={"foo": "bar"},
-            cookies=None,
-            timeout=client.timeout,
-        )
-
-    @patch("requests.delete")
-    def test_can_delete_request_with_cookies(self, mocked_delete):
-
-        mocked_delete.side_effect = lambda *args, **kwargs: True
-
+    @responses.activate
+    def test_can_delete_request_with_cookies(self):
+        responses.add(responses.DELETE, "http://www.foo.com/endpoint")
         client = util.ApiClient(
-            base_uri="http://www.foo.com", config={"version": API_VERSION_1}
+            base_uri="http://www.foo.com", config={"version": util.API_VERSION_1}
         )
         client.delete_request("endpoint", cookies={"foo": "bar"})
-
-        mocked_delete.assert_called_with(
-            client.url_for("endpoint"),
-            params=None,
-            data=None,
-            headers=None,
-            cookies={"foo": "bar"},
-            timeout=client.timeout,
+        expected_headers = {"Cookie": "foo=bar"}
+        actual_headers = responses.calls[0].request.headers
+        self.assertTrue(
+            set(expected_headers.items()).issubset(set(actual_headers.items()))
         )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38,py,py3},black
+envlist = py{36,37,38,py3},black
 skip_missing_interpreters = true
 isolated_build = true
 

--- a/zoomus/components/base.py
+++ b/zoomus/components/base.py
@@ -41,6 +41,7 @@ class BaseComponent(util.ApiClient):
         params = params or {}
         if self.config["version"] == util.API_VERSION_1:
             params.update(self.config)
+            del params["version"]
         if headers is None and self.config.get("version") == util.API_VERSION_2:
             headers = {
                 "Authorization": "Bearer {}".format(self.config.get("token")),


### PR DESCRIPTION
Copying directly from #22:

This fixes #12. I'm starting this PR out small as a draft, to give an idea of what it will look like, and make sure everybody is on board with the change.

This is to start using https://github.com/getsentry/responses instead of direct mocks for the actual API calls. The big advantage here is that we see what each actual full API call itself looks like, rather than just what the call to the internal methods looks like.

If an improper API call happens now, you see an error along the lines of either:
```
AssertionError: Expected call: post_request('foo', cookies=None, data=None, headers=None, params={'api_key': 'KEY', 'api_secret': 'SECRET', 'version': 1, 'foo': 'bar'})
Actual call: post_request('foo', cookies=None, data=None, headers=None, params={'api_key': 'KEY', 'api_secret': 'SECRET', 'foo': 'bar'})
```
or
```
requests.exceptions.ConnectionError: Connection refused by Responses: POST http://foo.com/users/ID/meetings?user_id=ID&topic=TOPIC&type=TYPE doesn't match Responses Mock
```

This should help a lot with diagnosing and preventing bugs like #21. In fact, you can see that I already discovered and fixed one bug thanks to this method; the `version` parameter was being passed along in the call to the API in v1. While this shouldn't be a breaking bug, it's certainly unintended.


This is now fully updated with the most recent tests and changes to the API.