### PR TITLE
added requests session to ApiClient

### DIFF
--- a/tests/zoomus/test_util.py
+++ b/tests/zoomus/test_util.py
@@ -81,7 +81,7 @@ class ApiClientTestCase(unittest.TestCase):
         client = util.ApiClient(base_uri="http://www.foo.com")
         self.assertEqual(client.url_for("bar/"), "http://www.foo.com/bar")
 
-    @patch("requests.get")
+    @patch.object(util.requests.Session, "get")
     def test_can_get_request(self, mocked_get):
 
         mocked_get.side_effect = lambda *args, **kwargs: True
@@ -98,7 +98,7 @@ class ApiClientTestCase(unittest.TestCase):
             timeout=client.timeout,
         )
 
-    @patch("requests.get")
+    @patch.object(util.requests.Session, "get")
     def test_can_get_request_with_params(self, mocked_get):
 
         mocked_get.side_effect = lambda *args, **kwargs: True
@@ -115,7 +115,7 @@ class ApiClientTestCase(unittest.TestCase):
             timeout=client.timeout,
         )
 
-    @patch("requests.get")
+    @patch.object(util.requests.Session, "get")
     def test_can_get_request_with_headers(self, mocked_get):
 
         mocked_get.side_effect = lambda *args, **kwargs: True
@@ -132,7 +132,7 @@ class ApiClientTestCase(unittest.TestCase):
             timeout=client.timeout,
         )
 
-    @patch("requests.post")
+    @patch.object(util.requests.Session, "post")
     def test_can_post_request(self, mocked_post):
 
         mocked_post.side_effect = lambda *args, **kwargs: True
@@ -151,7 +151,7 @@ class ApiClientTestCase(unittest.TestCase):
             timeout=client.timeout,
         )
 
-    @patch("requests.post")
+    @patch.object(util.requests.Session, "post")
     def test_can_post_request_with_params(self, mocked_post):
 
         mocked_post.side_effect = lambda *args, **kwargs: True
@@ -170,7 +170,7 @@ class ApiClientTestCase(unittest.TestCase):
             timeout=client.timeout,
         )
 
-    @patch("requests.post")
+    @patch.object(util.requests.Session, "post")
     def test_can_post_request_with_dict_data(self, mocked_post):
 
         mocked_post.side_effect = lambda *args, **kwargs: True
@@ -189,7 +189,7 @@ class ApiClientTestCase(unittest.TestCase):
             timeout=client.timeout,
         )
 
-    @patch("requests.post")
+    @patch.object(util.requests.Session, "post")
     def test_can_post_request_with_json_data(self, mocked_post):
 
         mocked_post.side_effect = lambda *args, **kwargs: True
@@ -208,7 +208,7 @@ class ApiClientTestCase(unittest.TestCase):
             timeout=client.timeout,
         )
 
-    @patch("requests.post")
+    @patch.object(util.requests.Session, "post")
     def test_can_post_request_with_headers(self, mocked_post):
 
         mocked_post.side_effect = lambda *args, **kwargs: True
@@ -227,7 +227,7 @@ class ApiClientTestCase(unittest.TestCase):
             timeout=client.timeout,
         )
 
-    @patch("requests.post")
+    @patch.object(util.requests.Session, "post")
     def test_can_post_request_with_cookies(self, mocked_post):
 
         mocked_post.side_effect = lambda *args, **kwargs: True
@@ -246,7 +246,7 @@ class ApiClientTestCase(unittest.TestCase):
             timeout=client.timeout,
         )
 
-    @patch("requests.patch")
+    @patch.object(util.requests.Session, "patch")
     def test_can_patch_request(self, mocked_patch):
 
         mocked_patch.side_effect = lambda *args, **kwargs: True
@@ -265,7 +265,7 @@ class ApiClientTestCase(unittest.TestCase):
             timeout=client.timeout,
         )
 
-    @patch("requests.patch")
+    @patch.object(util.requests.Session, "patch")
     def test_can_patch_request_with_params(self, mocked_patch):
 
         mocked_patch.side_effect = lambda *args, **kwargs: True
@@ -284,7 +284,7 @@ class ApiClientTestCase(unittest.TestCase):
             timeout=client.timeout,
         )
 
-    @patch("requests.patch")
+    @patch.object(util.requests.Session, "patch")
     def test_can_patch_request_with_dict_data(self, mocked_patch):
 
         mocked_patch.side_effect = lambda *args, **kwargs: True
@@ -303,7 +303,7 @@ class ApiClientTestCase(unittest.TestCase):
             timeout=client.timeout,
         )
 
-    @patch("requests.patch")
+    @patch.object(util.requests.Session, "patch")
     def test_can_patch_request_with_json_data(self, mocked_patch):
 
         mocked_patch.side_effect = lambda *args, **kwargs: True
@@ -322,7 +322,7 @@ class ApiClientTestCase(unittest.TestCase):
             timeout=client.timeout,
         )
 
-    @patch("requests.patch")
+    @patch.object(util.requests.Session, "patch")
     def test_can_patch_request_with_headers(self, mocked_patch):
 
         mocked_patch.side_effect = lambda *args, **kwargs: True
@@ -341,7 +341,7 @@ class ApiClientTestCase(unittest.TestCase):
             timeout=client.timeout,
         )
 
-    @patch("requests.patch")
+    @patch.object(util.requests.Session, "patch")
     def test_can_patch_request_with_cookies(self, mocked_patch):
 
         mocked_patch.side_effect = lambda *args, **kwargs: True
@@ -360,7 +360,7 @@ class ApiClientTestCase(unittest.TestCase):
             timeout=client.timeout,
         )
 
-    @patch("requests.delete")
+    @patch.object(util.requests.Session, "delete")
     def test_can_delete_request(self, mocked_delete):
 
         mocked_delete.side_effect = lambda *args, **kwargs: True
@@ -379,7 +379,7 @@ class ApiClientTestCase(unittest.TestCase):
             timeout=client.timeout,
         )
 
-    @patch("requests.delete")
+    @patch.object(util.requests.Session, "delete")
     def test_can_delete_request_with_params(self, mocked_delete):
 
         mocked_delete.side_effect = lambda *args, **kwargs: True
@@ -398,7 +398,7 @@ class ApiClientTestCase(unittest.TestCase):
             timeout=client.timeout,
         )
 
-    @patch("requests.delete")
+    @patch.object(util.requests.Session, "delete")
     def test_can_delete_request_with_dict_data(self, mocked_delete):
 
         mocked_delete.side_effect = lambda *args, **kwargs: True
@@ -417,7 +417,7 @@ class ApiClientTestCase(unittest.TestCase):
             timeout=client.timeout,
         )
 
-    @patch("requests.delete")
+    @patch.object(util.requests.Session, "delete")
     def test_can_delete_request_with_json_data(self, mocked_delete):
 
         mocked_delete.side_effect = lambda *args, **kwargs: True
@@ -436,7 +436,7 @@ class ApiClientTestCase(unittest.TestCase):
             timeout=client.timeout,
         )
 
-    @patch("requests.delete")
+    @patch.object(util.requests.Session, "delete")
     def test_can_delete_request_with_headers(self, mocked_delete):
 
         mocked_delete.side_effect = lambda *args, **kwargs: True
@@ -455,7 +455,7 @@ class ApiClientTestCase(unittest.TestCase):
             timeout=client.timeout,
         )
 
-    @patch("requests.delete")
+    @patch.object(util.requests.Session, "delete")
     def test_can_delete_request_with_cookies(self, mocked_delete):
 
         mocked_delete.side_effect = lambda *args, **kwargs: True

--- a/zoomus/util.py
+++ b/zoomus/util.py
@@ -30,6 +30,7 @@ class ApiClient(object):
         self.timeout = timeout
         for k, v in kwargs.items():
             setattr(self, k, v)
+        self.session = requests.Session()
 
     @property
     def timeout(self):
@@ -80,7 +81,7 @@ class ApiClient(object):
         """
         if headers is None and self.config.get("version") == API_VERSION_2:
             headers = {"Authorization": "Bearer {}".format(self.config.get("token"))}
-        return requests.get(
+        return self.session.get(
             self.url_for(endpoint), params=params, headers=headers, timeout=self.timeout
         )
 
@@ -104,7 +105,7 @@ class ApiClient(object):
                 "Authorization": "Bearer {}".format(self.config.get("token")),
                 "Content-Type": "application/json",
             }
-        return requests.post(
+        return self.session.post(
             self.url_for(endpoint),
             params=params,
             data=data,
@@ -133,7 +134,7 @@ class ApiClient(object):
                 "Authorization": "Bearer {}".format(self.config.get("token")),
                 "Content-Type": "application/json",
             }
-        return requests.patch(
+        return self.session.patch(
             self.url_for(endpoint),
             params=params,
             data=data,
@@ -159,7 +160,7 @@ class ApiClient(object):
             data = json.dumps(data)
         if headers is None and self.config.get("version") == API_VERSION_2:
             headers = {"Authorization": "Bearer {}".format(self.config.get("token"))}
-        return requests.delete(
+        return self.session.delete(
             self.url_for(endpoint),
             params=params,
             data=data,
@@ -183,7 +184,7 @@ class ApiClient(object):
             data = json.dumps(data)
         if headers is None and self.config.get("version") == API_VERSION_2:
             headers = {"Authorization": "Bearer {}".format(self.config.get("token"))}
-        return requests.put(
+        return self.session.put(
             self.url_for(endpoint),
             params=params,
             data=data,


### PR DESCRIPTION
Fixes #62 by adding requests session to ApiClient utility instances. This may be a naive approach, so please let me know if we need additional changes to support this.

- added session instance to ApiClient
- replaced requests.<method> with self.session.<method> calls
- updated mock patches to use util.requests.Session object patches in test_util.py