### PR TITLE
Add support to retrieve the details of the current user

### DIFF
--- a/tests/zoomus/components/user/test_me.py
+++ b/tests/zoomus/components/user/test_me.py
@@ -1,0 +1,43 @@
+import unittest
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+from zoomus import components
+
+
+def suite():
+    """Define all the tests of the module."""
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(GetV1TestCase))
+    return suite
+
+
+class GetV1TestCase(unittest.TestCase):
+    def setUp(self):
+        self.component = components.user.UserComponent(
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+        )
+
+    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
+    def test_can_get_me(self, mock_get_request):
+        self.component.me()
+        mock_get_request.assert_called_with("/user/me")
+
+
+class MeV2TestCase(unittest.TestCase):
+    def setUp(self):
+        self.component = components.user.UserComponentV2(
+            base_uri="http://foo.com", config={"api_key": "KEY", "api_secret": "SECRET"}
+        )
+
+    @patch.object(components.base.BaseComponent, "get_request", return_value=True)
+    def test_can_get_me(self, mock_get_request):
+        self.component.me()
+        mock_get_request.assert_called_with("/users/me")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zoomus/components/user.py
+++ b/zoomus/components/user.py
@@ -43,7 +43,7 @@ class UserComponent(base.BaseComponent):
 
 
 class UserComponentV2(base.BaseComponent):
-    def me(self, **kwargs):
+    def me(self):
         return self.get_request("/users/me")
 
     def list(self, **kwargs):

--- a/zoomus/components/user.py
+++ b/zoomus/components/user.py
@@ -9,6 +9,9 @@ from zoomus.components import base
 class UserComponent(base.BaseComponent):
     """Component dealing with all user related matters"""
 
+    def me(self):
+        return self.get_request("/user/me")
+
     def list(self, **kwargs):
         return self.post_request("/user/list", params=kwargs)
 
@@ -40,6 +43,9 @@ class UserComponent(base.BaseComponent):
 
 
 class UserComponentV2(base.BaseComponent):
+    def me(self, **kwargs):
+        return self.get_request("/users/me")
+
     def list(self, **kwargs):
         return self.get_request("/users", params=kwargs)
 


### PR DESCRIPTION
This PR adds support to retrieve the details of the authenticated user: https://marketplace.zoom.us/docs/guides/auth/oauth#me-context