### PR TITLE
Upgrade: /report/webinars and participants

### DIFF
--- a/zoomus/components/report.py
+++ b/zoomus/components/report.py
@@ -52,3 +52,15 @@ class ReportComponentV2(base.BaseComponent):
     def get_daily_report(self, **kwargs):
         util.require_keys(kwargs, ["month", "year"])
         return self.get_request("/report/daily", params=kwargs)
+
+    def get_webinar_participants_report(self, **kwargs):
+        util.require_keys(kwargs, "id")
+        return self.get_request(
+            "/report/webinars/{}/participants".format(kwargs.get("id")), params=kwargs
+        )
+
+    def get_webinar_report(self, **kwargs):
+        util.require_keys(kwargs, "id")
+        return self.get_request(
+            "/report/webinars/{}".format(kwargs.get("id")), params=kwargs
+        )


### PR DESCRIPTION
Added support for https://marketplace.zoom.us/docs/api-reference/zoom-api/reports/reportwebinardetails and https://marketplace.zoom.us/docs/api-reference/zoom-api/reports/reportwebinarparticipants