### PR TITLE
add method to report component to get meeting participants

### DIFF
--- a/tests/zoomus/components/report/test_get_meeting_participant_report.py
+++ b/tests/zoomus/components/report/test_get_meeting_participant_report.py
@@ -1,0 +1,36 @@
+import unittest
+
+from zoomus import components, util
+import responses
+
+
+def suite():
+    """Define all the tests of the module."""
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(GetMeetingParticipantReportV2TestCase))
+    return suite
+
+
+class GetMeetingParticipantReportV2TestCase(unittest.TestCase):
+    def setUp(self):
+        self.component = components.report.ReportComponentV2(
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
+        )
+
+    @responses.activate
+    def test_can_get_meeting_participant_report(self):
+        responses.add(responses.GET, "http://foo.com/report/meetings/42/participants")
+        self.component.get_meeting_participant_report(meeting_id="42")
+
+    def test_requires_meeting_id(self):
+        with self.assertRaisesRegexp(ValueError, "'meeting_id' must be set"):
+            self.component.get_meeting_participant_report()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/zoomus/components/report/test_get_meeting_participant_report.py
+++ b/tests/zoomus/components/report/test_get_meeting_participant_report.py
@@ -24,8 +24,19 @@ class GetMeetingParticipantReportV2TestCase(unittest.TestCase):
 
     @responses.activate
     def test_can_get_meeting_participant_report(self):
-        responses.add(responses.GET, "http://foo.com/report/meetings/42/participants")
+        responses.add(
+            responses.GET,
+            "http://foo.com/report/meetings/42/participants?meeting_id=42",
+        )
         self.component.get_meeting_participant_report(meeting_id="42")
+
+    @responses.activate
+    def test_encode_meeting_id(self):
+        responses.add(
+            responses.GET,
+            "http://foo.com/report/meetings/%252Fsomeidwith%252F%252Fslashes/participants?meeting_id=%25252Fsomeidwith%25252F%25252Fslashes",
+        )
+        self.component.get_meeting_participant_report(meeting_id="/someidwith//slashes")
 
     def test_requires_meeting_id(self):
         with self.assertRaisesRegexp(ValueError, "'meeting_id' must be set"):

--- a/zoomus/components/report.py
+++ b/zoomus/components/report.py
@@ -52,3 +52,10 @@ class ReportComponentV2(base.BaseComponent):
     def get_daily_report(self, **kwargs):
         util.require_keys(kwargs, ["month", "year"])
         return self.get_request("/report/daily", params=kwargs)
+
+    def get_meeting_participant_report(self, **kwargs):
+        util.require_keys(kwargs, ["meeting_id"])
+        return self.get_request(
+            "/report/meetings/{}/participants".format(kwargs.get("meeting_id")),
+            params=kwargs,
+        )

--- a/zoomus/components/report.py
+++ b/zoomus/components/report.py
@@ -55,6 +55,7 @@ class ReportComponentV2(base.BaseComponent):
 
     def get_meeting_participant_report(self, **kwargs):
         util.require_keys(kwargs, ["meeting_id"])
+        kwargs["meeting_id"] = util.encode_uuid(kwargs.get("meeting_id"))
         return self.get_request(
             "/report/meetings/{}/participants".format(kwargs.get("meeting_id")),
             params=kwargs,


### PR DESCRIPTION
This pull request provides a proposed addition to `report` component.  The method proved useful for us in building out some ETL operations from Zoom data.  It might prove useful for others who need to see who attended which meetings and for how long.

This commit implements the web service call for this Zoom API function:

https://marketplace.zoom.us/docs/api-reference/zoom-api/reports/reportmeetingparticipants

The implementation is exposed as a method on the report component.
Only a V2 API is implemented.  Test to ensure that meeting ID is
required is provided.