### PR TITLE
Add past_meeting property to client so the component is accessible

### DIFF
--- a/zoomus/client.py
+++ b/zoomus/client.py
@@ -137,3 +137,8 @@ class ZoomClient(util.ApiClient):
     def phone(self):
         """Get the phone component"""
         return self.components.get("phone")
+
+    @property
+    def past_meeting(self):
+        """Get the past meeting component"""
+        return self.components.get("past_meeting")


### PR DESCRIPTION
Resolves: #123 

The past_meeting component is not accessible from the client object. This PR adds a property to the client class making the component accessible.