### PR TITLE
Add user email update and check email endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ with ZoomClient('API_KEY', 'API_SECRET') as client:
 * client.user.create(...)
 * client.user.cust_create(...)
 * client.user.update(...)*
+* client.user.check_email(...)
+* client.user.update_email(...)
 * client.user.list(...)
 * client.user.pending(...)
 * client.user.get(...)

--- a/tests/zoomus/components/user/test_check_email.py
+++ b/tests/zoomus/components/user/test_check_email.py
@@ -1,0 +1,36 @@
+import unittest
+
+from zoomus import components, util
+import responses
+
+
+def suite():
+    """Define all the tests of the module."""
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(CheckEmailV2TestCase))
+    return suite
+
+
+class CheckEmailV2TestCase(unittest.TestCase):
+    def setUp(self):
+        self.component = components.user.UserComponentV2(
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
+        )
+
+    @responses.activate
+    def test_can_get(self):
+        responses.add(responses.GET, "http://foo.com/users/email?email=foo@bar.test")
+        self.component.check_email(email="foo@bar.test")
+
+    def test_requires_email(self):
+        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+            self.component.get()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/zoomus/components/user/test_update_email.py
+++ b/tests/zoomus/components/user/test_update_email.py
@@ -1,0 +1,37 @@
+import unittest
+
+from zoomus import components, util
+import responses
+
+
+def suite():
+    """Define all the tests of the module."""
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(UpdateEmailV2TestCase))
+    return suite
+
+
+class UpdateEmailV2TestCase(unittest.TestCase):
+    def setUp(self):
+        self.component = components.user.UserComponentV2(
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
+        )
+
+    @responses.activate
+    def test_can_update(self):
+        responses.add(responses.PUT, "http://foo.com/users/42/email")
+        response = self.component.update_email(id="42")
+        self.assertEqual(response.request.body, '{"id": "42"}')
+
+    def test_requires_id(self):
+        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+            self.component.update_email()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zoomus/components/user.py
+++ b/zoomus/components/user.py
@@ -50,6 +50,37 @@ class UserComponentV2(base.BaseComponent):
         util.require_keys(kwargs, "id")
         return self.patch_request("/users/{}".format(kwargs.get("id")), data=kwargs)
 
+    def check_email(self, **kwargs):
+        """
+        Verify if a user’s email is registered with Zoom.
+        Expects:
+            - email: string (Email address)
+        Example:
+            /users/email?email=foo@baar.test
+        """
+        util.require_keys(kwargs, "email")
+        return self.get_request("/users/email", params=kwargs)
+
+    def update_email(self, **kwargs):
+        """
+        Change a user’s  on a Zoom account that has managed domain set up.
+        If the Zoom Account in which the user belongs, has multiple , the email to be updated must match one of the managed domains.
+
+        Official docs: https://marketplace.zoom.us/docs/api-reference/zoom-api/users/useremailupdate
+
+        Expects:
+            - id: string (User ID)
+            - email: string (New email address)
+
+        Example:
+            /users/42/email
+
+            json:
+                {"email": "foo@bar.new"}
+        """
+        util.require_keys(kwargs, "id")
+        return self.put_request("/users/{}/email".format(kwargs.get("id")), data=kwargs)
+
     def delete(self, **kwargs):
         util.require_keys(kwargs, "id")
         return self.delete_request("/users/{}".format(kwargs.get("id")), params=kwargs)

--- a/zoomus/util.py
+++ b/zoomus/util.py
@@ -182,7 +182,10 @@ class ApiClient(object):
         if data and not is_str_type(data):
             data = json.dumps(data)
         if headers is None and self.config.get("version") == API_VERSION_2:
-            headers = {"Authorization": "Bearer {}".format(self.config.get("token"))}
+            headers = {
+                "Authorization": "Bearer {}".format(self.config.get("token")),
+                "Content-Type": "application/json",
+            }
         return requests.put(
             self.url_for(endpoint),
             params=params,


### PR DESCRIPTION
Add the following API endpoints to the client:

- Check the user's email: GET /users/email (https://marketplace.zoom.us/docs/api-reference/zoom-api/users/useremail)
- Update the user's email: PUT /users/42/email (https://marketplace.zoom.us/docs/api-reference/zoom-api/users/useremailupdate)