### PR TITLE
Remove extra r in requirements-tests.txt

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ isolated_build = true
 
 [testenv]
 deps =
-    -rrequirements-tests.txt
+    -requirements-tests.txt
 
 commands =
     nosetests {posargs}


### PR DESCRIPTION
I was running tests and getting `ERROR:   py36: could not install deps [-rrequirements-tests.txt]; v = InvocationError('/Users/jmaggie/Desktop/zoomus/.tox/py36/bin/python -m pip install -rrequirements-tests.txt', 1)`

Which I believe is because here we are defining that it is looking for file `rrequirements-tests.txt` but the file name is actually `requirements-tests.txt`