### PR TITLE
Rooms & update meeting status, user settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ with ZoomClient('API_KEY', 'API_SECRET') as client:
 * client.user.pending(...)
 * client.user.get(...)
 * client.user.get_by_email(...)
+* client.user.get_settings(...)
+* client.user.update_settings(...)
 
 * client.meeting.get(...)
 * client.meeting.end(...)

--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ with ZoomClient('API_KEY', 'API_SECRET') as client:
 * client.group.add_members(...)
 * client.group.delete_member(...)
 
+* client.room.list(...)
+* client.room.create(...)
+* client.room.get(...)
+* client.room.get_settings(...)
+* client.room.get_devices(...)
+* client.room.delete(...)
+* client.room.check_in_or_out(...)
+* client.room.update(...)
+
 ## Running the Tests
 
 ### Simple

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -144,6 +144,10 @@ Zoom User Methods provided by zoomus client:
 
   client.user.get_by_email(...)
 
+  client.user.get_settings(...)
+
+  client.user.update_settings(...)
+
 
 .. _Zoom Meeting Methods provided by zoomus client:
 
@@ -170,6 +174,8 @@ Zoom Meeting Methods provided by zoomus client:
   client.meeting.list_registrants(...)
 
   client.meeting.update_registrant_status(...)
+
+  client.meeting.update_status(...)
 
 
 .. _Zoom Report Methods provided by zoomus client:
@@ -256,6 +262,27 @@ Zoom Groups Methods provided by zoomus client:
 
   client.group.delete_member(...)
 
+Zoom Rooms Methods provided by zoomus client:
+**********************************************
+*Refer Zoom Rooms API Docs for params info* `https://marketplace.zoom.us/docs/api-reference/zoom-api/rooms/`
+
+::
+
+  client.room.list(...)
+
+  client.room.create(...)
+
+  client.room.get(...)
+
+  client.room.get_settings(...)
+
+  client.room.get_devices(...)
+
+  client.room.delete(...)
+
+  client.room.check_in_or_out(...)
+
+  client.room.update(...)
 
 .. _Running the Tests:
 

--- a/tests/zoomus/components/meeting/test_update_status.py
+++ b/tests/zoomus/components/meeting/test_update_status.py
@@ -1,0 +1,36 @@
+import unittest
+
+from zoomus import components, util
+import responses
+
+
+def suite():
+    """Define all the tests of the module."""
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(UpdateStatusV2TestCase))
+    return suite
+
+class UpdateStatusV2TestCase(unittest.TestCase):
+    def setUp(self):
+        self.component = components.meeting.MeetingComponentV2(
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
+        )
+
+    @responses.activate
+    def test_can_update_status(self):
+        responses.add(responses.PUT, "http://foo.com/meetings/42/status")
+        response = self.component.update_status(id="42", action="foo")
+        self.assertEqual(response.request.body, '{"action": "foo"}')
+
+    def test_requires_id(self):
+        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+            self.component.update()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/zoomus/components/meeting/test_update_status.py
+++ b/tests/zoomus/components/meeting/test_update_status.py
@@ -10,6 +10,7 @@ def suite():
     suite.addTest(unittest.makeSuite(UpdateStatusV2TestCase))
     return suite
 
+
 class UpdateStatusV2TestCase(unittest.TestCase):
     def setUp(self):
         self.component = components.meeting.MeetingComponentV2(

--- a/tests/zoomus/components/rooms/test_check_in_or_out.py
+++ b/tests/zoomus/components/rooms/test_check_in_or_out.py
@@ -1,0 +1,36 @@
+import unittest
+
+from zoomus import components, util
+import responses
+
+
+def suite():
+    """Define all the tests of the module."""
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(CheckInOrOutV2TestCase))
+    return suite
+
+
+class CheckInOrOutV2TestCase(unittest.TestCase):
+    def setUp(self):
+        self.component = components.room.RoomComponentV2(
+            base_uri="http://foo.com",
+            config={
+                "token": "token",
+                "version": util.API_VERSION_2,
+            },
+        )
+
+    @responses.activate
+    def test_can_check_in_or_out(self):
+        responses.add(responses.PATCH, "http://foo.com/rooms/42/events")
+        response = self.component.check_in_or_out(id="42")
+        self.assertEqual(response.request.body, '{"id": "42"}')
+
+    def test_requires_room_id(self):
+        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+            self.component.update()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/zoomus/components/rooms/test_create.py
+++ b/tests/zoomus/components/rooms/test_create.py
@@ -1,0 +1,40 @@
+import unittest
+
+from zoomus import components, util
+import responses
+
+
+def suite():
+    """Define all the tests of the module."""
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(CreateV2TestCase))
+    return suite
+
+
+class CreateV2TestCase(unittest.TestCase):
+    def setUp(self):
+        self.component = components.room.RoomComponentV2(
+            base_uri="http://foo.com",
+            config={
+                "token": "token",
+                "version": util.API_VERSION_2,
+            },
+        )
+
+    @responses.activate
+    def test_can_create(self):
+        responses.add(responses.POST, "http://foo.com/rooms")
+        response = self.component.create(name="bar", type="foo")
+        self.assertEqual(response.request.body, '{"name": "bar", "type": "foo"}')
+
+    def test_requires_type(self):
+        with self.assertRaisesRegexp(ValueError, "'type' must be set"):
+            self.component.create(name="bar")
+
+    def test_requires_name(self):
+        with self.assertRaisesRegexp(ValueError, "'name' must be set"):
+            self.component.create()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/zoomus/components/rooms/test_delete.py
+++ b/tests/zoomus/components/rooms/test_delete.py
@@ -1,0 +1,35 @@
+import unittest
+
+from zoomus import components, util
+import responses
+
+
+def suite():
+    """Define all the tests of the module."""
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(DeleteV2TestCase))
+    return suite
+
+
+class DeleteV2TestCase(unittest.TestCase):
+    def setUp(self):
+        self.component = components.room.RoomComponentV2(
+            base_uri="http://foo.com",
+            config={
+                "token": "token",
+                "version": util.API_VERSION_2,
+            },
+        )
+
+    @responses.activate
+    def test_can_get(self):
+        responses.add(responses.DELETE, "http://foo.com/rooms/42?id=42")
+        self.component.delete(id="42")
+
+    def test_requires_room_id(self):
+        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+            self.component.delete()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/zoomus/components/rooms/test_get.py
+++ b/tests/zoomus/components/rooms/test_get.py
@@ -1,0 +1,35 @@
+import unittest
+
+from zoomus import components, util
+import responses
+
+
+def suite():
+    """Define all the tests of the module."""
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(GetV2TestCase))
+    return suite
+
+
+class GetV2TestCase(unittest.TestCase):
+    def setUp(self):
+        self.component = components.room.RoomComponentV2(
+            base_uri="http://foo.com",
+            config={
+                "token": "token",
+                "version": util.API_VERSION_2,
+            },
+        )
+
+    @responses.activate
+    def test_can_get(self):
+        responses.add(responses.GET, "http://foo.com/rooms/42?id=42")
+        self.component.get(id="42")
+
+    def test_requires_room_id(self):
+        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+            self.component.get()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/zoomus/components/rooms/test_get_devices.py
+++ b/tests/zoomus/components/rooms/test_get_devices.py
@@ -1,0 +1,35 @@
+import unittest
+
+from zoomus import components, util
+import responses
+
+
+def suite():
+    """Define all the tests of the module."""
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(GetDevicesV2TestCase))
+    return suite
+
+
+class GetDevicesV2TestCase(unittest.TestCase):
+    def setUp(self):
+        self.component = components.room.RoomComponentV2(
+            base_uri="http://foo.com",
+            config={
+                "token": "token",
+                "version": util.API_VERSION_2,
+            },
+        )
+
+    @responses.activate
+    def test_can_get_devices(self):
+        responses.add(responses.GET, "http://foo.com/rooms/42/devices")
+        self.component.get_devices(id="42")
+
+    def test_requires_room_id(self):
+        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+            self.component.get()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/zoomus/components/rooms/test_get_settings.py
+++ b/tests/zoomus/components/rooms/test_get_settings.py
@@ -1,0 +1,41 @@
+import unittest
+
+from zoomus import components, util
+import responses
+
+
+def suite():
+    """Define all the tests of the module."""
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(GetSettingsV2TestCase))
+    return suite
+
+
+class GetSettingsV2TestCase(unittest.TestCase):
+    def setUp(self):
+        self.component = components.room.RoomComponentV2(
+            base_uri="http://foo.com",
+            config={
+                "token": "token",
+                "version": util.API_VERSION_2,
+            },
+        )
+
+    @responses.activate
+    def test_can_get_settings(self):
+        responses.add(
+            responses.GET, "http://foo.com/rooms/42/settings?setting_type=meeting"
+        )
+        self.component.get_settings(id="42", setting_type="meeting")
+
+    def test_requires_setting_type(self):
+        with self.assertRaisesRegexp(ValueError, "'setting_type' must be set"):
+            self.component.get_settings(id="42")
+
+    def test_requires_room_id(self):
+        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+            self.component.get_settings()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/zoomus/components/rooms/test_list.py
+++ b/tests/zoomus/components/rooms/test_list.py
@@ -1,0 +1,31 @@
+import unittest
+
+from zoomus import components, util
+import responses
+
+
+def suite():
+    """Define all the tests of the module."""
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(ListV2TestCase))
+    return suite
+
+
+class ListV2TestCase(unittest.TestCase):
+    def setUp(self):
+        self.component = components.room.RoomComponentV2(
+            base_uri="http://foo.com",
+            config={
+                "token": "token",
+                "version": util.API_VERSION_2,
+            },
+        )
+
+    @responses.activate
+    def test_can_get(self):
+        responses.add(responses.GET, "http://foo.com/rooms")
+        self.component.list()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/zoomus/components/rooms/test_update.py
+++ b/tests/zoomus/components/rooms/test_update.py
@@ -1,0 +1,36 @@
+import unittest
+
+from zoomus import components, util
+import responses
+
+
+def suite():
+    """Define all the tests of the module."""
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(UpdateV2TestCase))
+    return suite
+
+
+class UpdateV2TestCase(unittest.TestCase):
+    def setUp(self):
+        self.component = components.room.RoomComponentV2(
+            base_uri="http://foo.com",
+            config={
+                "token": "token",
+                "version": util.API_VERSION_2,
+            },
+        )
+
+    @responses.activate
+    def test_can_update(self):
+        responses.add(responses.PATCH, "http://foo.com/rooms/42")
+        response = self.component.update(id="42")
+        self.assertEqual(response.request.body, '{"id": "42"}')
+
+    def test_requires_room_id(self):
+        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+            self.component.update()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/zoomus/components/user/test_get_settings.py
+++ b/tests/zoomus/components/user/test_get_settings.py
@@ -1,0 +1,36 @@
+import unittest
+
+from zoomus import components, util
+import responses
+
+
+def suite():
+    """Define all the tests of the module."""
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(GetSettingsV2TestCase))
+    return suite
+
+
+class GetSettingsV2TestCase(unittest.TestCase):
+    def setUp(self):
+        self.component = components.user.UserComponentV2(
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
+        )
+
+    @responses.activate
+    def test_can_get_settings(self):
+        responses.add(responses.GET, "http://foo.com/users/42/settings")
+        response = self.component.get_settings(id="42")
+
+    def test_requires_id(self):
+        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+            self.component.update_settings()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/zoomus/components/user/test_update_settings.py
+++ b/tests/zoomus/components/user/test_update_settings.py
@@ -1,0 +1,37 @@
+import unittest
+
+from zoomus import components, util
+import responses
+
+
+def suite():
+    """Define all the tests of the module."""
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(UpdateSettingsV2TestCase))
+    return suite
+
+
+class UpdateSettingsV2TestCase(unittest.TestCase):
+    def setUp(self):
+        self.component = components.user.UserComponentV2(
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
+        )
+
+    @responses.activate
+    def test_can_update_settings(self):
+        responses.add(responses.PATCH, "http://foo.com/users/42/settings")
+        response = self.component.update_settings(id="42", schedule_meeting="foo")
+        self.assertEqual(response.request.body, '{"schedule_meeting": "foo"}')
+
+    def test_requires_id(self):
+        with self.assertRaisesRegexp(ValueError, "'id' must be set"):
+            self.component.update_settings()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/zoomus/test_client.py
+++ b/tests/zoomus/test_client.py
@@ -62,6 +62,7 @@ class ZoomClientTestCase(unittest.TestCase):
                     "user",
                     "webinar",
                     "group",
+                    "room",
                 ]
             ),
             set(client.components.keys()),
@@ -100,6 +101,9 @@ class ZoomClientTestCase(unittest.TestCase):
         self.assertIsInstance(
             client.components["live_stream"],
             components.live_stream.LiveStreamComponentV2,
+        )
+        self.assertIsInstance(
+            client.components["room"], components.room.RoomComponentV2
         )
 
     def test_api_version_defaults_to_2(self):
@@ -199,6 +203,10 @@ class ZoomClientTestCase(unittest.TestCase):
     def test_can_get_group_component(self):
         client = ZoomClient("KEY", "SECRET")
         self.assertIsInstance(client.group, components.group.GroupComponentV2)
+
+    def test_can_get_room_component(self):
+        client = ZoomClient("KEY", "SECRET")
+        self.assertIsInstance(client.room, components.room.RoomComponentV2)
 
     def test_can_use_client_with_context(self):
         with ZoomClient("KEY", "SECRET") as client:

--- a/tests/zoomus/test_client.py
+++ b/tests/zoomus/test_client.py
@@ -52,6 +52,7 @@ class ZoomClientTestCase(unittest.TestCase):
             set(
                 [
                     "contacts",
+                    "group",
                     "live_stream",
                     "meeting",
                     "metric",
@@ -59,10 +60,9 @@ class ZoomClientTestCase(unittest.TestCase):
                     "phone",
                     "recording",
                     "report",
+                    "room",
                     "user",
                     "webinar",
-                    "group",
-                    "room",
                 ]
             ),
             set(client.components.keys()),

--- a/zoomus/client.py
+++ b/zoomus/client.py
@@ -30,9 +30,9 @@ COMPONENT_CLASSES = {
         "phone": components.phone.PhoneComponentV2,
         "recording": components.recording.RecordingComponentV2,
         "report": components.report.ReportComponentV2,
+        "room": components.room.RoomComponentV2,
         "user": components.user.UserComponentV2,
         "webinar": components.webinar.WebinarComponentV2,
-        "room": components.room.RoomComponentV2,
     },
 }
 

--- a/zoomus/client.py
+++ b/zoomus/client.py
@@ -32,6 +32,7 @@ COMPONENT_CLASSES = {
         "report": components.report.ReportComponentV2,
         "user": components.user.UserComponentV2,
         "webinar": components.webinar.WebinarComponentV2,
+        "room": components.room.RoomComponentV2,
     },
 }
 
@@ -175,3 +176,8 @@ class ZoomClient(util.ApiClient):
     def group(self):
         """Get the group component"""
         return self.components.get("group")
+
+    @property
+    def room(self):
+        """Get the room component"""
+        return self.components.get("room")

--- a/zoomus/components/__init__.py
+++ b/zoomus/components/__init__.py
@@ -14,4 +14,5 @@ from . import (
     report,
     user,
     webinar,
+    room,
 )

--- a/zoomus/components/__init__.py
+++ b/zoomus/components/__init__.py
@@ -12,7 +12,7 @@ from . import (
     phone,
     recording,
     report,
+    room,
     user,
     webinar,
-    room,
 )

--- a/zoomus/components/meeting.py
+++ b/zoomus/components/meeting.py
@@ -71,6 +71,12 @@ class MeetingComponentV2(base.BaseComponent):
             "/meetings/{}".format(kwargs.get("id")), params=kwargs
         )
 
+    def update_status(self, **kwargs):
+        util.require_keys(kwargs, "id")
+        return self.put_request(
+            "/meetings/{}/status".format(kwargs.pop("id")), data=kwargs
+        )
+
     def add_registrant(self, **kwargs):
         util.require_keys(kwargs, "id")
         return self.post_request(

--- a/zoomus/components/room.py
+++ b/zoomus/components/room.py
@@ -1,0 +1,45 @@
+"""Zoom.us REST API Python Client -- Room component"""
+
+from __future__ import absolute_import
+
+from zoomus import util
+from zoomus.components import base
+
+
+class RoomComponentV2(base.BaseComponent):
+    def create(self, **kwargs):
+        util.require_keys(kwargs, ["name", "type"])
+        return self.post_request("/rooms", data=kwargs)
+
+    def get(self, **kwargs):
+        util.require_keys(kwargs, "id")
+        return self.get_request("/rooms/{}".format(kwargs.get("id")), params=kwargs)
+
+    def get_devices(self, **kwargs):
+        util.require_keys(kwargs, "id")
+        return self.get_request(
+            "/rooms/{}/devices".format(kwargs.get("id")), params=kwargs
+        )
+
+    def get_settings(self, **kwargs):
+        util.require_keys(kwargs, ["id", "setting_type"])
+        return self.get_request(
+            "/rooms/{}/settings".format(kwargs.pop("id")), params=kwargs
+        )
+
+    def list(self, **kwargs):
+        return self.get_request("/rooms/", params=kwargs)
+
+    def update(self, **kwargs):
+        util.require_keys(kwargs, "id")
+        return self.patch_request("/rooms/{}".format(kwargs.get("id")), data=kwargs)
+
+    def check_in_or_out(self, **kwargs):
+        util.require_keys(kwargs, "id")
+        return self.patch_request(
+            "/rooms/{}/events".format(kwargs.get("id")), data=kwargs
+        )
+
+    def delete(self, **kwargs):
+        util.require_keys(kwargs, "id")
+        return self.delete_request("/rooms/{}".format(kwargs.get("id")), params=kwargs)

--- a/zoomus/components/user.py
+++ b/zoomus/components/user.py
@@ -106,3 +106,9 @@ class UserComponentV2(base.BaseComponent):
     def get(self, **kwargs):
         util.require_keys(kwargs, "id")
         return self.get_request("/users/{}".format(kwargs.get("id")), params=kwargs)
+
+    def get_settings(self, **kwargs):
+        util.require_keys(kwargs, "id")
+        return self.get_request(
+            "/users/{}/settings".format(kwargs.pop("id")), params=kwargs
+        )

--- a/zoomus/components/user.py
+++ b/zoomus/components/user.py
@@ -56,6 +56,12 @@ class UserComponentV2(base.BaseComponent):
         util.require_keys(kwargs, "id")
         return self.patch_request("/users/{}".format(kwargs.get("id")), data=kwargs)
 
+    def update_settings(self, **kwargs):
+        util.require_keys(kwargs, "id")
+        return self.patch_request(
+            "/users/{}/settings".format(kwargs.pop("id")), data=kwargs
+        )
+
     def update_status(self, **kwargs):
         util.require_keys(kwargs, ["id", "action"])
         return self.put_request(


### PR DESCRIPTION
Adds basic room manipulation functionality and a way to update meeting statuses (eg.: end a meeting)

Although some of the room functionalities might be limited to Pro accounts, I thought it might be useful to someone else as well.
