### PR TITLE
Add support for live streams to webinars

### DIFF
--- a/tests/zoomus/components/live_stream/test_get.py
+++ b/tests/zoomus/components/live_stream/test_get.py
@@ -1,0 +1,45 @@
+import unittest
+
+from zoomus import components, util
+import responses
+
+
+def suite():
+    """Define all the tests of the module."""
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(GetV2TestCase))
+    return suite
+
+
+class GetV2TestCase(unittest.TestCase):
+    def setUp(self):
+        self.component = components.live_stream.LiveStreamComponentV2(
+            base_uri="http://foo.com",
+            config={
+                "api_key": "KEY",
+                "api_secret": "SECRET",
+                "version": util.API_VERSION_2,
+            },
+        )
+
+    @responses.activate
+    def test_can_get(self):
+        responses.add(responses.GET, "http://foo.com/meetings/ID/livestream")
+        self.component.get_livestream(meeting_id="ID")
+
+    def test_requires_id(self):
+        with self.assertRaisesRegexp(ValueError, "'meeting_id' must be set"):
+            self.component.get_livestream()
+
+    @responses.activate
+    def test_can_get_webinar(self):
+        responses.add(responses.GET, "http://foo.com/webinars/ID/livestream")
+        self.component.get_webinar_livestream(webinar_id="ID")
+
+    def test_requires_id_webinar(self):
+        with self.assertRaisesRegexp(ValueError, "'webinar_id' must be set"):
+            self.component.get_webinar_livestream()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/zoomus/components/live_stream/test_update.py
+++ b/tests/zoomus/components/live_stream/test_update.py
@@ -55,5 +55,37 @@ class UpdateV2TestCase(unittest.TestCase):
             self.assertEqual(context.exception.message, "'meeting_id' must be set")
 
 
+    @responses.activate
+    def test_can_update_webinars(self):
+        responses.add(responses.PATCH, "http://foo.com/webinars/42/livestream")
+        response = self.component.update_webinar(
+            webinar_id="42", stream_url="https://foo.bar", stream_key="12345"
+        )
+        self.assertEqual(
+            response.request.body,
+            '{"webinar_id": "42", "stream_url": "https://foo.bar", "stream_key": "12345"}',
+        )
+
+    @responses.activate
+    def test_can_update_webinar_wildcard(self):
+        responses.add(responses.PATCH, "http://foo.com/webinars/42/livestream")
+
+        data = {
+            "webinar_id": "42",
+            "stream_url": "https://foo.bar",
+            "stream_key": "12345",
+        }
+
+        response = self.component.update_webinar(**data)
+        self.assertEqual(
+            response.request.body,
+            '{"webinar_id": "42", "stream_url": "https://foo.bar", "stream_key": "12345"}',
+        )
+
+    def test_requires_webinar_id(self):
+        with self.assertRaises(ValueError) as context:
+            self.component.update_webinar()
+            self.assertEqual(context.exception.message, "'webinar_id' must be set")
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/zoomus/components/live_stream/test_update_status.py
+++ b/tests/zoomus/components/live_stream/test_update_status.py
@@ -49,6 +49,40 @@ class UpdateV2TestCase(unittest.TestCase):
             self.component.update_status()
             self.assertEqual(context.exception.message, "'meeting_id' must be set")
 
+    @responses.activate
+    def test_can_update_webinar_livestream(self):
+        responses.add(responses.PATCH, "http://foo.com/webinars/42/livestream/status")
+        response = self.component.update_webinar_status(
+            webinar_id="42",
+            action="stop",
+            settings={"active_speaker_name": False, "display_name": "inc"},
+        )
+        self.assertEqual(
+            response.request.body,
+            '{"webinar_id": "42", "action": "stop", "settings": {"active_speaker_name": false, "display_name": "inc"}}',
+        )
+
+    @responses.activate
+    def test_can_update_webinar_wildcard(self):
+        responses.add(responses.PATCH, "http://foo.com/webinars/42/livestream/status")
+
+        data = {
+            "webinar_id": "42",
+            "action": "stop",
+            "settings": {"active_speaker_name": False, "display_name": "inc"},
+        }
+
+        response = self.component.update_webinar_status(**data)
+        self.assertEqual(
+            response.request.body,
+            '{"webinar_id": "42", "action": "stop", "settings": {"active_speaker_name": false, "display_name": "inc"}}',
+        )
+
+    def test_requires_webinar_id(self):
+        with self.assertRaises(ValueError) as context:
+            self.component.update_webinar_status()
+            self.assertEqual(context.exception.message, "'webinar_id' must be set")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/zoomus/components/live_stream.py
+++ b/zoomus/components/live_stream.py
@@ -13,6 +13,17 @@ class LiveStreamComponentV2(base.BaseComponent):
         - stream_url: string (URL)
         - stream_key: string
         - page_url: string (URL)
+
+        Response content sample:
+        ```json
+        {
+        "page_url": "https://example.com/livestream/123",
+        "stream_key": "contact-it@example.com",
+        "stream_url": "https://example.com/livestream"
+        }
+        ```
+        Returns:
+        requests.Response: The response object
         """
         util.require_keys(kwargs, "meeting_id")
         return self.patch_request(
@@ -26,9 +37,117 @@ class LiveStreamComponentV2(base.BaseComponent):
         - meeting_id: int
         - action (start|stop)
         - settings: dict
+
+        Response content sample:
+        ```json
+        {
+        "action": "start",
+        "settings": {
+            "active_speaker_name": true,
+            "display_name": "Jill Chill"
+        }
+        ```
+
+        Returns:
+        requests.Response: The response object
         """
         util.require_keys(kwargs, "meeting_id")
         return self.patch_request(
             "/meetings/{}/livestream/status".format(kwargs.get("meeting_id")),
             data=kwargs,
         )
+
+    def get_livestream(self, **kwargs):
+        """
+        Get the meeting's live stream details
+        Expects:
+        - meeting_id: int
+
+        Response content sample:
+        ```json
+        {
+        "page_url": "https://example.com/livestream/123",
+        "stream_key": "contact-ic@example.com",
+        "stream_url": "https://example.com/livestream"
+        }
+        ```
+
+        Returns:
+        requests.Response: The response object
+        """
+        util.require_keys(kwargs, "meeting_id")
+        return self.get_request("/meetings/{}/livestream".format(kwargs.get("meeting_id")),
+                                 params=kwargs)
+
+    def update_webinar(self, **kwargs):
+        """
+        Use this API to update the webinar's stream information.
+        Expects:
+        - webinar_id: int
+        - stream_url: string (URL)
+        - stream_key: string
+        - page_url: string (URL)
+
+        Response content sample:
+        ```json
+        {
+        "page_url": "https://example.com/livestream/123",
+        "stream_key": "contact-it@example.com",
+        "stream_url": "https://example.com/livestream"
+        }
+        ```
+        Returns:
+        requests.Response: The response object
+        """
+        util.require_keys(kwargs, "webinar_id")
+        return self.patch_request(
+            "/webinars/{}/livestream".format(kwargs.get("webinar_id")), data=kwargs
+        )
+
+    def update_webinar_status(self, **kwargs):
+        """
+        Use this API to update the status of a webinar's live stream.
+        Expects:
+        - webinar_id: int
+        - action (start|stop)
+        - settings: dict
+
+        Response content sample:
+        ```json
+        {
+        "action": "start",
+        "settings": {
+            "active_speaker_name": true,
+            "display_name": "Jill Chill"
+        }
+        ```
+
+        Returns:
+        requests.Response: The response object
+        """
+        util.require_keys(kwargs, "webinar_id")
+        return self.patch_request(
+            "/webinars/{}/livestream/status".format(kwargs.get("webinar_id")),
+            data=kwargs,
+        )
+
+
+    def get_webinar_livestream(self, **kwargs):
+        """Get the webinar's live stream details
+        Expects:
+        - webinar_id: int
+        Response content sample:
+        ```json
+        {
+        "page_url": "https://example.com/livestream/123",
+        "stream_key": "contact-ic@example.com",
+        "stream_url": "https://example.com/livestream"
+        }
+        ```
+
+        Returns:
+        requests.Response: The response object
+        """
+        util.require_keys(kwargs, "webinar_id")
+        return self.get_request("/webinars/{}/livestream".format(kwargs.get("webinar_id")),
+                                 params=kwargs)


### PR DESCRIPTION
This PR adds support for live streams for the webinars.

I adds support to:
- Get live stream details from meeting/webinar.
- Update the webinar live stream settings.
- Update the webinar live stream status