### PR TITLE
Fix OAUTH token formatting

### DIFF
--- a/zoomus/client.py
+++ b/zoomus/client.py
@@ -108,14 +108,11 @@ class ZoomClient(util.ApiClient):
         return
 
     def refresh_token(self):
-        self.config["token"] = (
-            util.generate_token(
+        self.config["token"] = util.generate_token(
                 self.config["oauth_uri"],
                 self.config["api_key"],
                 self.config["api_secret"],
-                self.config["api_account_id"],
-            ),
-        )
+                self.config["api_account_id"])
 
     @property
     def api_key(self):


### PR DESCRIPTION
This PR resolves an issue I'm seeing while updating my Zoom integration.  OAUTH calls were failing, and investigating the token inside the ZoomClient revealed that the token was being stored as `($token_string,)`, rather than just `$token_string`.  This led to some... obvious issues where none of the auth worked :)
